### PR TITLE
Update Serilog.Sinks.MSSqlServer.csproj to support the use of Managed Identities through the connectionstring

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -69,8 +69,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />


### PR DESCRIPTION
Updated package references to Microsoft.Data.SqlClient 3.0.0, doing so makes using the UseAzureManagedIdentity and AzureServiceTokenProviderResource no longer necessary to use when working with Managed Identities. The update package allows the Authentication parameter to be used in the connectionstring like this: "Server=xxxx;Database=xxxx;Authentication=Active Directory Managed Identity;"