### PR TITLE
Add trimming to rendered message and message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,13 +460,13 @@ _BigInt data type:_ For very large log tables, if you absolutely require an iden
 
 This column stores the formatted output (property placeholders are replaced with property values). It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
 
-In case `DataLength` is set to a specific value different from -1 or 0, any message longer than that length will be effectively trimmed down to that size. Example: `DataLength` is set to 15 and the message is "this is a very long message" (without the quotes), the trimmed text stored in the database will be: "this is a ve..." (again without quotes).
+In case `DataLength` is set to a specific value different from -1, any message longer than that length will be effectively truncated to that size. Example: `DataLength` is set to 15 and the message is "this is a very long message" (without the quotes), the truncated text stored in the database will be: "this is a ve..." (again without quotes).
 
 ### MessageTemplate
 
 This column stores the log event message with the property placeholders. It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
 
-In case `DataLength` is set to a specific value different from -1 or 0, any template text longer than that length will be effectively trimmed down to that size. Any trimming ignores all differences between the tokens in the template meaning that a template might get cut off in the middle of a property token. Example: `DataLength` is set to 20 and the message template is "a long {NumberOfCharacters} template text" (without the quotes), the final template stored in the database will be: "a long {NumberOfC..." (again without quotes).
+In case `DataLength` is set to a specific value different from -1, any template text longer than that length will be effectively truncated to that size. Any truncating ignores all differences between the tokens in the template meaning that a template might get cut off in the middle of a property token. Example: `DataLength` is set to 20 and the message template is "a long {NumberOfCharacters} template text" (without the quotes), the final template stored in the database will be: "a long {NumberOfC..." (again without quotes).
 
 ### Level
 
@@ -495,6 +495,8 @@ When the `ConvertToUtc` property is set to `true`, the time stamp is adjusted to
 ### Exception
 
 When an exception is logged as part of the log event, the exception message is stored here automatically. The `DataType` must be `nvarchar`.
+
+Similar to the columns `Message` and `MessageTemplate`, setting `DataLength` of `Exception` to a specific value different from -1 will effectively truncate any exception message to the stated length in `DataLength`.
 
 ### Properties
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A flag specifiying if the log events table should be created if it does not exis
 ### EnlistInTransaction
 
 A flag to make logging SQL commands take part in ambient transactions. It defaults to `false`.
-Logging operations could be affected from surrounding `TransactionScope's in the code, leading to log data
+Logging operations could be affected from surrounding `TransactionScope`'s in the code, leading to log data
 being removed on a transaction rollback. This is by default prevented by the sink adding `Enlist=false` to
 the `ConnectionString` that is passed. This option can be used to change this behavior so that `Enlist=true`
 is added instead (which is the default for SQL connections) and logging commands might be part of transactions.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A flag specifiying if the log events table should be created if it does not exis
 ### EnlistInTransaction
 
 A flag to make logging SQL commands take part in ambient transactions. It defaults to `false`.
-Logging operations could be affected from surrounding `TransactionScope´s in the code, leading to log data
+Logging operations could be affected from surrounding `TransactionScopeï¿½s in the code, leading to log data
 being removed on a transaction rollback. This is by default prevented by the sink adding `Enlist=false` to
 the `ConnectionString` that is passed. This option can be used to change this behavior so that `Enlist=true`
 is added instead (which is the default for SQL connections) and logging commands might be part of transactions.
@@ -460,9 +460,13 @@ _BigInt data type:_ For very large log tables, if you absolutely require an iden
 
 This column stores the formatted output (property placeholders are replaced with property values). It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
 
+In case `DataLength` is set to a specific value different from -1 or 0, any message longer than that length will be effectively trimmed down to that size. Example: `DataLength` is set to 15 and the message is "this is a very long message" (without the quotes), the trimmed text stored in the database will be: "this is a ve..." (again without quotes).
+
 ### MessageTemplate
 
 This column stores the log event message with the property placeholders. It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
+
+In case `DataLength` is set to a specific value different from -1 or 0, any template text longer than that length will be effectively trimmed down to that size. Any trimming ignores all differences between the tokens in the template meaning that a template might get cut off in the middle of a property token. Example: `DataLength` is set to 20 and the message template is "a long {NumberOfCharacters} template text" (without the quotes), the final template stored in the database will be: "a long {NumberOfC..." (again without quotes).
 
 ### Level
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A flag specifiying if the log events table should be created if it does not exis
 ### EnlistInTransaction
 
 A flag to make logging SQL commands take part in ambient transactions. It defaults to `false`.
-Logging operations could be affected from surrounding `TransactionScope�s in the code, leading to log data
+Logging operations could be affected from surrounding `TransactionScope's in the code, leading to log data
 being removed on a transaction rollback. This is by default prevented by the sink adding `Enlist=false` to
 the `ConnectionString` that is passed. This option can be used to change this behavior so that `Enlist=true`
 is added instead (which is the default for SQL connections) and logging commands might be part of transactions.

--- a/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
@@ -1,0 +1,15 @@
+namespace Serilog.Sinks.MSSqlServer.Extensions
+{
+    internal static class StringExtensions
+    {
+        public static string Truncate(this string value, int maxLength, string suffix)
+        {
+            if (value == null) return null;
+            var suffixLength = suffix?.Length ?? 0;
+            if (maxLength <= suffixLength) return string.Empty;
+
+            var correctedMaxLength = maxLength - suffixLength;
+            return value.Length <= maxLength ? value : $"{value.Substring(0, correctedMaxLength)}{suffix}";
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -67,7 +67,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             var logMessage = logEvent.RenderMessage(_formatProvider);
             var maxAllowedMessageLength = _columnOptions.Message.DataLength;
 
-            if (0 < maxAllowedMessageLength && logMessage.Length > maxAllowedMessageLength)
+            if (maxAllowedMessageLength > 0 && logMessage.Length > maxAllowedMessageLength)
             {
                 logMessage = logMessage.Substring(0, maxAllowedMessageLength - 3);
                 logMessage = $"{logMessage}...";
@@ -81,7 +81,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             var messageTemplate = logEvent.MessageTemplate.Text;
             var maxAllowedMessageTemplateLength = _columnOptions.MessageTemplate.DataLength;
 
-            if (0 < maxAllowedMessageTemplateLength && messageTemplate.Length > maxAllowedMessageTemplateLength)
+            if (maxAllowedMessageTemplateLength > 0 && messageTemplate.Length > maxAllowedMessageTemplateLength)
             {
                 messageTemplate = messageTemplate.Substring(0, maxAllowedMessageTemplateLength - 3);
                 messageTemplate = $"{messageTemplate}...";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Extensions/StringExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,91 @@
+using Serilog.Sinks.MSSqlServer.Extensions;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Extensions
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class StringExtensionsTests
+    {
+        [Fact]
+        public void ReturnNullWhenInputStringIsNull()
+        {
+            // Arrange
+            string inputMessage = null;
+
+            // Act
+            var nonTruncatedMessage = inputMessage.Truncate(5, "...");
+
+            // Assert
+            Assert.Null(nonTruncatedMessage);
+        }
+
+        [Fact]
+        public void ReturnEmptyWhenInputStringIsEmpty()
+        {
+            // Arrange
+            var inputMessage = "";
+
+            // Act
+            var nonTruncatedMessage = inputMessage.Truncate(5, "...");
+
+            // Assert
+            Assert.Equal(inputMessage, nonTruncatedMessage);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-5)]
+        public void ReturnEmptyStringWhenRequestedMaxValueIsZeroOrSmaller(int maxValue)
+        {
+            // Arrange
+            var inputMessage = "A simple test message";
+
+            // Act
+            var nonTruncatedMessage = inputMessage.Truncate(maxValue, "...");
+
+            // Assert
+            Assert.Equal("", nonTruncatedMessage);
+        }
+
+        [Fact]
+        public void ReturnTruncatedStringWithSuffix()
+        {
+            // Arrange
+            var inputMessage = "A simple test message";
+
+            // Act
+            var truncatedMessage = inputMessage.Truncate(15, "...");
+
+            // Assert
+            Assert.Equal("A simple tes...", truncatedMessage);
+        }
+
+        [Fact]
+        public void ReturnTruncatedStringWithEmptySuffix()
+        {
+            // Arrange
+            var inputMessage = "A simple test message";
+
+            // Act
+            var truncatedMessage = inputMessage.Truncate(15, "");
+
+            // Assert
+            Assert.Equal("A simple test m", truncatedMessage);
+        }
+
+        [Fact]
+        public void ReturnTruncatedStringWithNullSuffix()
+        {
+            // Arrange
+            var inputMessage = "A simple test message";
+
+            // Act
+            var truncatedMessage = inputMessage.Truncate(15, null);
+
+            // Assert
+            Assert.Equal("A simple test m", truncatedMessage);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
-        public void GetStandardColumnNameAndValueForMessageReturnsTrimmedSimpleTextMessageKeyValue()
+        public void GetStandardColumnNameAndValueForMessageReturnsTruncatedSimpleTextMessageKeyValue()
         {
             // Arrange
             const string messageText = "Test message";
@@ -127,7 +127,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
-        public void GetStandardColumnNameAndValueForMessageReturnsTrimmedMessageKeyValueWithDefaultFormatting()
+        public void GetStandardColumnNameAndValueForMessageReturnsTruncatedMessageKeyValueWithDefaultFormatting()
         {
             // Arrange
             const string expectedText = "2.4 seconds...";
@@ -173,7 +173,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
-        public void GetStandardColumnNameAndValueForMessageReturnsTrimmedMessageKeyValueWithCustomFormatting()
+        public void GetStandardColumnNameAndValueForMessageReturnsTruncatedMessageKeyValueWithCustomFormatting()
         {
             // Arrange
             const string expectedText = "2,4 seconds...";
@@ -219,7 +219,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
-        public void GetStandardColumnNameAndValueForMessageTemplateReturnsTrimmedMessageTemplateKeyValue()
+        public void GetStandardColumnNameAndValueForMessageTemplateReturnsTruncatedMessageTemplateKeyValue()
         {
             // Arrange
             var messageTemplate = new MessageTemplate(new List<MessageTemplateToken>() { new PropertyToken("NumberProperty", "{NumberProperty}") });

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -64,6 +64,26 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
+        public void GetStandardColumnNameAndValueForMessageReturnsSimpleTextMessageKeyValueWithMaxDataLengthDefined()
+        {
+            // Arrange
+            const string messageText = "A long test message";
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken(messageText) }),
+                new List<LogEventProperty>());
+            var columnOptions = new Serilog.Sinks.MSSqlServer.ColumnOptions { Message = { DataLength = -1 } };
+            SetupSut(columnOptions);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.Message, logEvent);
+
+            // Assert
+            Assert.Equal("Message", result.Key);
+            Assert.Equal(messageText, result.Value);
+        }
+
+        [Fact]
         public void GetStandardColumnNameAndValueForMessageReturnsTrimmedSimpleTextMessageKeyValue()
         {
             // Arrange


### PR DESCRIPTION
- Add separate functions to trim the rendered message and message template text when the corresponding database fields are too small for saving the data, implementing #209.
- Add unit tests to check the trimming effect when called.
- Update README.md with explanation about the trimming effect.