### PR TITLE
Removed support for obsolete .NET Framework 4.5.2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,7 +19,6 @@ If you are opening a feature request, you can ignore this template. Bug reports 
 [ ] .NET Framework 4.8
 [ ] .NET Framework 4.7
 [ ] .NET Framework 4.6.x
-[ ] .NET Framework 4.5.x
 OS: 
 
 >> Provide a *simple* reproduction of your Serilog configuration code:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
           automatic_release_tag: "v${{ env.VERSION }}"
           title: "v${{ env.VERSION }}"
           files: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that writes events to Microsoft SQL Server. This sink will write the log event data to a table and can optionally also store the properties inside an XML or JSON column so they can be queried. Important properties can also be written to their own separate columns.
 
 **Package** - [Serilog.Sinks.MSSqlServer](http://nuget.org/packages/serilog.sinks.mssqlserver)
-| **Minimum Platforms** - .NET Framework 4.5.2, .NET Core 3.1, .NET Standard 2.0
+| **Minimum Platforms** - .NET Framework 4.6.2, .NET Core 3.1, .NET Standard 2.0
 
 #### Topics
 
@@ -87,14 +87,11 @@ Because of the way external configuration has been implemented in various .NET f
 
 | Your Framework | TFM | Project Types | External Configuration |
 | --- | --- | --- |  --- |
-| .NET Framework 4.5.2 | `net452` | app or library | _System.Configuration_ |
 | .NET Framework 4.6.2+ | `net462` | app or library | _System.Configuration_ |
 | .NET Framework 4.6.2+ | `net462` | app or library | _Microsoft.Extensions.Configuration_ |
 | .NET Standard 2.0 | `netstandard2.0` | library only | _Microsoft.Extensions.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _System.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _Microsoft.Extensions.Configuration_ |
-
-Support for .NET Framework 4.5.2 is tied to the Windows 8.1 lifecycle with support scheduled to end in April 2022 (https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/).
 
 Although it's possible to use both XML and _M.E.C_ configuration with certain frameworks, this is not supported, unintended consequences are possible, and a warning will be emitted to `SelfLog`. If you actually require multiple configuration sources, the _M.E.C_ builder-pattern is designed to support this, and your syntax will be consistent across configuration sources.
 

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
@@ -23,7 +23,6 @@ using Serilog.Sinks.MSSqlServer.Configuration.Factories;
 
 // The "Hybrid" configuration system supports both Microsoft.Extensions.Configuration and System.Configuration.
 // This is necessary because .NET Framework 4.6.1+ and .NET Core 2.0+ apps support both approaches, whereas the
-// older .NET Framework 4.5.2 only supports System.Configuration and .NET Standard 2.0 only supports M.E.C.
 
 namespace Serilog
 {

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -19,7 +19,7 @@ using Serilog.Formatting;
 using Serilog.Sinks.MSSqlServer;
 using Serilog.Sinks.MSSqlServer.Configuration.Factories;
 
-// System.Configuration support for .NET Framework 4.5.2 libraries and apps.
+// System.Configuration support for .NET Framework 4.6.2 libraries and apps.
 
 namespace Serilog
 {

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -4,7 +4,7 @@
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
     <VersionPrefix>5.7.1</VersionPrefix>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net452;net462;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net472;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.MSSqlServer</AssemblyName>
@@ -29,7 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Whenever these are updated, also update versions in packages.config for net452 -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -88,18 +87,6 @@
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
     <Compile Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticator.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Compile Include="Configuration\Extensions\System.Configuration\**\*.cs" />
-    <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
-    <Compile Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStub.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
-    <VersionPrefix>5.7.1</VersionPrefix>
+    <VersionPrefix>5.8.0</VersionPrefix>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net462;net472;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Serilog.Sinks.MSSqlServer/packages.config
+++ b/src/Serilog.Sinks.MSSqlServer/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Serilog" version="2.5.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.3.0" targetFramework="net452" />
-  <package id="System.Data.SqlClient" Version="4.6.0" targetFramework="net452" />
-</packages>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/App.config
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/App.config
@@ -7,7 +7,7 @@
     <section name="SinkOptionsConfig" type="Serilog.Configuration.MSSqlServerConfigurationSection, Serilog.Sinks.MSSqlServer"/>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
 
   <connectionStrings>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net462;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net472;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.MSSqlServer.Tests</AssemblyName>
@@ -36,15 +36,6 @@
     <None Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStubTests.cs" />
     <None Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorTests.cs" />
     <!-- ItemGroups below with TFM conditions will re-include the compile targets -->
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <Compile Include="Configuration\Extensions\System.Configuration\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
* Removed support for obsolete .NET Framework 4.5.2.
* Version bumped to 5.8.
* Do not create prereleases when updating main branch. Create regular releases instead.
