### PR TITLE
Removing deprecated Microsoft.Azure.Services.AppAuthentication nuget package and replacing it by Azure.Identity

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <!-- Whenever these are updated, also update versions in packages.config for net452 -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -81,7 +81,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
@@ -106,6 +105,30 @@
     <None Include="Configuration\Factories\IMSSqlServerSinkFactory.cs" />
     <None Include="Configuration\Factories\MSSqlServerSinkFactory.cs" />
     <None Include="Images\serilog-sink-nuget.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Azure.Identity">
+      <Version>1.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Azure.Identity">
+      <Version>1.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Azure.Identity">
+      <Version>1.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Azure.Identity">
+      <Version>1.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Services.AppAuthentication;
+using Azure.Identity;
 using Serilog.Sinks.MSSqlServer.Platform;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken");
 
             // Act + assert
-            await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync <AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Hello,

The IT security team of my company will not go live if the Microsoft.Azure.Services.AppAuthentication nuget package is used as reference.

The goal of this PR is to replace it by Azure.Identity without causing any regression.

If this fix isn't enough, feel free to do it on another branch and closed mine.

Again, without this critical security change, it's one year lost for my team.

This is link to #400 

Regards