### PR TITLE
Removing deprecated Microsoft.Azure.Services.AppAuthentication nuget package and replacing it by Azure.Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Because of the way external configuration has been implemented in various .NET f
 | --- | --- | --- |  --- |
 | .NET Framework 4.6.2+ | `net462` | app or library | _System.Configuration_ |
 | .NET Framework 4.6.2+ | `net462` | app or library | _Microsoft.Extensions.Configuration_ |
+| .NET Framework 4.7.2+ | `net472` | app or library | _Azure.Identity_ |
 | .NET Standard 2.0 | `netstandard2.0` | library only | _Microsoft.Extensions.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _System.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _Microsoft.Extensions.Configuration_ |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that writes events to Microsoft SQL Server. This sink will write the log event data to a table and can optionally also store the properties inside an XML or JSON column so they can be queried. Important properties can also be written to their own separate columns.
 
 **Package** - [Serilog.Sinks.MSSqlServer](http://nuget.org/packages/serilog.sinks.mssqlserver)
-| **Minimum Platforms** - .NET Framework 4.6.2, .NET Core 3.1, .NET Standard 2.0
+| **Minimum Platforms** - .NET Framework 4.7.2, .NET Core 3.1, .NET Standard 2.0
 
 #### Topics
 
@@ -20,6 +20,7 @@ A Serilog sink that writes events to Microsoft SQL Server. This sink will write 
 * [Troubleshooting](#troubleshooting)
 * [Querying Property Data](#querying-property-data)
 * [Deprecated Features](#deprecated-features)
+* [Deprecated Packages](#deprecated-packages)
 
 ## Quick Start
 
@@ -89,7 +90,6 @@ Because of the way external configuration has been implemented in various .NET f
 | --- | --- | --- |  --- |
 | .NET Framework 4.6.2+ | `net462` | app or library | _System.Configuration_ |
 | .NET Framework 4.6.2+ | `net462` | app or library | _Microsoft.Extensions.Configuration_ |
-| .NET Framework 4.7.2+ | `net472` | app or library | _Azure.Identity_ |
 | .NET Standard 2.0 | `netstandard2.0` | library only | _Microsoft.Extensions.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _System.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _Microsoft.Extensions.Configuration_ |
@@ -831,3 +831,10 @@ Feature | Notes
 `Binary` and `VarBinary` | Due to the way Serilog represents property data internally, it isn't possible for the sink to access property data as a byte array, so the sink can't write to these column types.
 
 Most deprecated features are still available, but they are marked with the `[Obsolete]` attribute (which results in a compiler warning in your project) and will be removed in a future release. You should switch to the replacement implementations as soon as possible. Where possible, internally these are converted to the replacement implementation so that they only exist at the configuration level.
+
+## Deprecated Packages
+
+### _Microsoft.Azure.Services.AppAuthentication_
+
+As this package has vulnerabilities reported as Very High in Veracode, a switch to the [Azure.Identity](https://www.nuget.org/packages/Azure.Identity/) package has been made after the version 5.7.2.
+This package imply that your current solution/project target version need to be .NET Framework 4.7.2+ or .NET Core 3.1+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that writes events to Microsoft SQL Server. This sink will write the log event data to a table and can optionally also store the properties inside an XML or JSON column so they can be queried. Important properties can also be written to their own separate columns.
 
 **Package** - [Serilog.Sinks.MSSqlServer](http://nuget.org/packages/serilog.sinks.mssqlserver)
-| **Minimum Platforms** - .NET Framework 4.7.2, .NET Core 3.1, .NET Standard 2.0
+| **Minimum Platforms** - .NET Framework 4.6.2, .NET Core 3.1, .NET Standard 2.0
 
 #### Topics
 
@@ -836,5 +836,6 @@ Most deprecated features are still available, but they are marked with the `[Obs
 
 ### _Microsoft.Azure.Services.AppAuthentication_
 
-As this package has vulnerabilities reported as Very High in Veracode, a switch to the [Azure.Identity](https://www.nuget.org/packages/Azure.Identity/) package has been made after the version 5.7.2.
-This package imply that your current solution/project target version need to be .NET Framework 4.7.2+ or .NET Core 3.1+
+If your current or future technical stack is using Azure, especially a database as logs storage component, please read the following :
+The package Microsoft.Azure.Services.AppAuthentication has vulnerabilities reported as Very High in Veracode, a switch to the [Azure.Identity](https://www.nuget.org/packages/Azure.Identity/) package has been made after the version 5.7.1.
+This package change imply that your current solution/project target version need to be .NET Framework 4.7.2+ or .NET Core 3.1+.

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Azure.Identity" Version="1.6.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -29,7 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -80,7 +81,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -22,16 +22,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
             _tenantId = tenantId;
-            _defaultAzureCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
-            {
-                ExcludeEnvironmentCredential = true,
-                ExcludeManagedIdentityCredential = true,
-                ExcludeVisualStudioCredential = true,
-                ExcludeAzureCliCredential = true,
-                ExcludeAzurePowerShellCredential = true,
-                ExcludeSharedTokenCacheCredential = true,
-                InteractiveBrowserTenantId = _tenantId
-            });
+            _defaultAzureCredential = new DefaultAzureCredential();
         }
 
         public async Task<string> GetAuthenticationToken()
@@ -42,7 +33,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             }
 
             var accessToken = await _defaultAzureCredential.GetTokenAsync(
-                new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }) { }
+                new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }, tenantId: _tenantId) { }
             ).ConfigureAwait(false);
 
             return accessToken.Token;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -22,7 +22,10 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
             _tenantId = tenantId;
-            _defaultAzureCredential = new DefaultAzureCredential();
+            _defaultAzureCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                InteractiveBrowserTenantId = _tenantId
+            });
         }
 
         public async Task<string> GetAuthenticationToken()
@@ -33,8 +36,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             }
 
             var accessToken = await _defaultAzureCredential.GetTokenAsync(
-                new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }, tenantId: _tenantId) { }
-            ).ConfigureAwait(false);
+                new TokenRequestContext(new[] { _azureServiceTokenProviderResource })).ConfigureAwait(false);
 
             return accessToken.Token;
         }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -30,22 +30,15 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 
         public async Task<string> GetAuthenticationToken()
         {
-            try
+            if (!_useAzureManagedIdentity)
             {
-                if (!_useAzureManagedIdentity)
-                {
-                    return await Task.FromResult((string)null).ConfigureAwait(false);
-                }
-
-                var accessToken = await _defaultAzureCredential.GetTokenAsync(
-                    new TokenRequestContext(new[] { _azureServiceTokenProviderResource })).ConfigureAwait(false);
-
-                return accessToken.Token;
+                return await Task.FromResult((string)null).ConfigureAwait(false);
             }
-            catch(Exception e)
-            {
-                throw new AuthenticationFailedException(e.Message);
-            }
+
+            var accessToken = await _defaultAzureCredential.GetTokenAsync(
+                new TokenRequestContext(new[] { _azureServiceTokenProviderResource })).ConfigureAwait(false);
+
+            return accessToken.Token;
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
                 new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }) { }
             ).ConfigureAwait(false);
 
-            return !string.IsNullOrWhiteSpace(accessToken.Token) ? accessToken.Token : null;
+            return accessToken.Token;
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -22,7 +22,15 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
             _tenantId = tenantId;
-            _defaultAzureCredential = new DefaultAzureCredential();
+            _defaultAzureCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                ExcludeEnvironmentCredential = true,
+                ExcludeManagedIdentityCredential = true,
+                ExcludeVisualStudioCredential = true,
+                ExcludeAzureCliCredential = true,
+                ExcludeAzurePowerShellCredential = true,
+                ExcludeSharedTokenCacheCredential = true
+            });
         }
 
         public async Task<string> GetAuthenticationToken()

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
                 new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }) { }
             ).ConfigureAwait(false);
 
-            return accessToken.Token;
+            return !string.IsNullOrWhiteSpace(accessToken.Token) ? accessToken.Token : null;
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -29,7 +29,8 @@ namespace Serilog.Sinks.MSSqlServer.Platform
                 ExcludeVisualStudioCredential = true,
                 ExcludeAzureCliCredential = true,
                 ExcludeAzurePowerShellCredential = true,
-                ExcludeSharedTokenCacheCredential = true
+                ExcludeSharedTokenCacheCredential = true,
+                InteractiveBrowserTenantId = _tenantId
             });
         }
 
@@ -41,7 +42,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             }
 
             var accessToken = await _defaultAzureCredential.GetTokenAsync(
-                new TokenRequestContext(scopes: new string[] { _azureServiceTokenProviderResource }, tenantId: _tenantId) { }
+                new TokenRequestContext(new[] { $"{_azureServiceTokenProviderResource}.default" }) { }
             ).ConfigureAwait(false);
 
             return accessToken.Token;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken");
 
             // Act + assert
-            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.Services.AppAuthentication;
+using Azure.Identity;
 using Serilog.Sinks.MSSqlServer.Platform;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken");
 
             // Act + assert
-            await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken");
 
             // Act + assert
-            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new AzureManagedServiceAuthenticator(true, "https://database.windows.net/", "TestTennantId");
 
             // Act + assert
-            await Assert.ThrowsAsync<CredentialUnavailableException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Hello,

The IT security team of my company will not go live if the Microsoft.Azure.Services.AppAuthentication nuget package is used as reference.

The goal of this PR is to replace it by Azure.Identity without causing any regression.

If this fix isn't enough, feel free to do it on another branch and closed mine.

Again, without this critical security change, it's one year lost for my team.

This is link to https://github.com/serilog-mssql/serilog-sinks-mssqlserver/issues/400

Regards