### PR TITLE
417 vulnerable nuget dependencies minimal fix

### DIFF
--- a/sample/AppConfigDemo/AppConfigDemo.csproj
+++ b/sample/AppConfigDemo/AppConfigDemo.csproj
@@ -35,46 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.SqlClient, Version=1.13.20136.2, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.SqlClient.1.1.3\lib\net46\Microsoft.Data.SqlClient.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.3.1.4\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=4.45.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Identity.Client.4.45.0\lib\net461\Microsoft.Identity.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Abstractions.6.21.0\lib\net461\Microsoft.IdentityModel.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.JsonWebTokens.6.21.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.6.21.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.6.21.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.6.21.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.6.21.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.9.0\lib\net46\Serilog.dll</HintPath>
-    </Reference>
+    <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.4\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+  </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -84,19 +48,7 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=6.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.6.21.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/sample/AppConfigDemo/packages.config
+++ b/sample/AppConfigDemo/packages.config
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.SqlClient" version="1.1.3" targetFramework="net461" />
-  <package id="Microsoft.Data.SqlClient.SNI" version="1.1.0" targetFramework="net461" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.Primitives" version="3.1.4" targetFramework="net461" />
+  <!--<package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.4" targetFramework="net462" />-->
+  <package id="Microsoft.Extensions.Primitives" version="3.1.4" targetFramework="net462" />
   <package id="Microsoft.Identity.Client" version="4.45.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.21.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.21.0" targetFramework="net462" />
@@ -11,13 +9,13 @@
   <package id="Microsoft.IdentityModel.Protocols" version="6.21.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.21.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.21.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
-  <package id="Serilog" version="2.9.0" targetFramework="net461" />
-  <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net461" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
-  <package id="System.Data.Common" version="4.3.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+  <package id="Serilog" version="2.9.0" targetFramework="net462" />
+  <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
+  <package id="System.Data.Common" version="4.3.0" targetFramework="net462" />
   <package id="System.IdentityModel.Tokens.Jwt" version="6.21.0" targetFramework="net462" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net462" />
 </packages>

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -59,18 +59,19 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.4" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStub.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.4" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
@@ -78,11 +79,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net472' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.4" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -129,11 +129,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         /// <returns>A completed task</returns>
         public Task OnEmptyBatchAsync() =>
-#if NET452
-            Task.FromResult(false);
-#else
             Task.CompletedTask;
-#endif
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlBulkCopyWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlBulkCopyWrapper.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Threading.Tasks;
-#if NET452
-using System.Data.SqlClient;
-#else
 using Microsoft.Data.SqlClient;
-#endif
 
 namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapper.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Data;
-#if NET452
-using System.Data.SqlClient;
-#else
 using Microsoft.Data.SqlClient;
-#endif
 
 namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionStringBuilderWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionStringBuilderWrapper.cs
@@ -1,8 +1,4 @@
-﻿#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
+﻿using Microsoft.Data.SqlClient;
 
 namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionWrapper.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
 {
@@ -16,15 +12,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
         public SqlConnectionWrapper(string connectionString, string accessToken)
         {
             _sqlConnection = new SqlConnection(connectionString);
-#if NET452
-            if (accessToken != null)
-            {
-                throw new InvalidOperationException(
-                    $"SqlConnection access token is set target framework that does not support it. Refer to MSSQLServer sink documentation for details.");
-            }
-#else
             _sqlConnection.AccessToken = accessToken;
-#endif
         }
 
         public string ConnectionString => _sqlConnection.ConnectionString;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -15,13 +15,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Sinks.MSSqlServer\Serilog.Sinks.MSSqlServer.csproj" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Dapper.StrongName" Version="1.50.5" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Dapper.StrongName" Version="2.0.123" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,8 +42,6 @@
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
     <Compile Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStubTests.cs" />
@@ -53,8 +51,6 @@
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <Compile Remove="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStubTests.cs" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
@@ -68,9 +64,6 @@
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
     <Compile Remove="Configuration\Extensions\System.Configuration\**\*.cs" />
     <Compile Remove="Configuration\Implementations\System.Configuration\**\*.cs" />
     <Compile Remove="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStubTests.cs" />

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/XmlPropertyFormatterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/XmlPropertyFormatterTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer.Output;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Output
 {
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
     public class XmlPropertyFormatterTests
     {
         [Fact]

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlBulkBatchWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlBulkBatchWriterTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Platform
 {
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
     public class SqlBulkBatchWriterTests : IDisposable
     {
         private const string _tableName = "TestTableName";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlBulkCopyWrapperTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlBulkCopyWrapperTests.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-#if NET452
-using System.Data.SqlClient;
-#else
 using Microsoft.Data.SqlClient;
-#endif
+using Xunit;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
-using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Platform.SqlClient
 {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapperTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapperTests.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-#if NET452
-using System.Data.SqlClient;
-#else
 using Microsoft.Data.SqlClient;
-#endif
 using Xunit;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionStringBuilderWrapperTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionStringBuilderWrapperTests.cs
@@ -1,12 +1,6 @@
-﻿#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
-using Xunit;
-using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+﻿using Xunit;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;
-using System;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Platform.SqlClient
 {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionWrapperTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlConnectionWrapperTests.cs
@@ -1,30 +1,12 @@
-﻿#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
-using Xunit;
+﻿using Xunit;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;
-using System;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Platform.SqlClient
 {
     [Trait(TestCategory.TraitName, TestCategory.Unit)]
     public class SqlConnectionWrapperTests
     {
-        [Fact]
-        public void InitializeThrowsIfCalledWithAuthenticationTokenOnDotNetFramework452ButNotOnOtherTargets()
-        {
-#if NET452
-            Assert.Throws<InvalidOperationException>(() => new SqlConnectionWrapper(DatabaseFixture.LogEventsConnectionString, "AuthenticationToken"));
-#else
-            // Should not throw
-            using (_ = new SqlConnectionWrapper(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Master", "AuthenticationToken"))
-            { }
-#endif
-        }
-
         [Fact]
         public void CreateCommandReturnsSqlCommandWrapper()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlLogEventWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlLogEventWriterTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Platform
 {
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
     public class SqlLogEventWriterTests
     {
         private const string _tableName = "TestTableName";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
 using System.Globalization;
 using System.Linq;
 using Dapper;
+using Microsoft.Data.SqlClient;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.TestUtils
 {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-#if NET452
-using System.Data.SqlClient;
-#else
-using Microsoft.Data.SqlClient;
-#endif
 using System.Globalization;
 using System.Linq;
 using Dapper;
 using FluentAssertions;
+using Microsoft.Data.SqlClient;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TransactionTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TransactionTests.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
+    [Trait(TestCategory.TraitName, TestCategory.Integration)]
     public class TransactionTests : DatabaseTestsBase
     {
         public TransactionTests(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
Fixed critical issue from #417. Moderate issue can be fixed only by removing dependency Microsoft.Azure.Services.AppAuthentication in a later release of this sink.