### PR TITLE
Coverlet code coverage

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,3 +21,9 @@ jobs:
         with:
           name: bin-net6
           path: src\Serilog.Sinks.MSSqlServer\bin\Release\net6.0
+
+      - name: Upload testresults artifact with code coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: testresults
+          path: test\Serilog.Sinks.MSSqlServer.Tests\TestResults

--- a/Build.ps1
+++ b/Build.ps1
@@ -54,7 +54,7 @@ if ($SkipTests -eq $false) {
 
         echo "build: Testing project in $test"
 
-        & dotnet test -c Release
+        & dotnet test -c Release --collect "XPlat Code Coverage"
         if($LASTEXITCODE -ne 0) { exit 3 }
 
         Pop-Location

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Dapper.StrongName" Version="2.0.123" />
     <PackageVersion Include="Moq" Version="4.18.2" />

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -52,6 +52,10 @@
     <PackageReference Include="System.IO.FileSystem.Primitives" />
     <PackageReference Include="System.Resources.ResourceManager" />
     <PackageReference Include="System.Text.Encoding.Extensions" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />


### PR DESCRIPTION
* Added coverlet.collector to the tests project, but only for .NET 6 because it does not work with .NET Framework.
* Added the --collect parameter when executing tests in Build.ps1
* Publish TestResults folder in PR Validation workflow to enable manual manual download and observation of the coverage during PRs.