### PR TITLE
478 autocreatedb no exception if db exists

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCommandExecutor.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCommandExecutor.cs
@@ -32,6 +32,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             catch (Exception ex)
             {
                 HandleException(ex);
+                throw;
             }
         }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCreateDatabaseWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCreateDatabaseWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using static System.FormattableString;
 
 namespace Serilog.Sinks.MSSqlServer.Platform
@@ -15,6 +16,15 @@ namespace Serilog.Sinks.MSSqlServer.Platform
         public string DatabaseName => _databaseName;
 
         public string GetSql()
-            => Invariant($"CREATE DATABASE [{_databaseName}]");
+        {
+            var sql = new StringBuilder();
+
+            sql.AppendLine(Invariant($"IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = '{_databaseName}')"));
+            sql.AppendLine("BEGIN");
+            sql.AppendLine(Invariant($"CREATE DATABASE [{_databaseName}]"));
+            sql.AppendLine("END");
+
+            return sql.ToString();
+        }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCommandExecutorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCommandExecutorTests.cs
@@ -100,7 +100,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             };
 
             // Act
-            _sut.Execute();
+            Assert.Throws<InvalidOperationException>(() => _sut.Execute());
 
             // Assert
             Assert.True(handlerCalled);
@@ -124,7 +124,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             };
 
             // Act
-            _sut.Execute();
+            Assert.Throws<InvalidOperationException>(() => _sut.Execute());
 
             // Assert
             Assert.True(handlerCalled);
@@ -148,7 +148,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             };
 
             // Act
-            _sut.Execute();
+            Assert.Throws<InvalidOperationException>(() => _sut.Execute());
 
             // Assert
             Assert.True(handlerCalled);
@@ -172,7 +172,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             };
 
             // Act
-            _sut.Execute();
+            Assert.Throws<InvalidOperationException>(() => _sut.Execute());
 
             // Assert
             Assert.True(handlerCalled);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCreateDatabaseWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCreateDatabaseWriterTests.cs
@@ -12,7 +12,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
         {
             // Arrange
             const string databaseName = "LogDatabase";
-            const string expectedResult = "CREATE DATABASE [LogDatabase]";
+            const string expectedResult = "IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'LogDatabase')\r\nBEGIN\r\nCREATE DATABASE [LogDatabase]\r\nEND\r\n";
             var sut = new SqlCreateDatabaseWriter(databaseName);
 
             // Act
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
         {
             // Arrange
             const string databaseName = "Log Data Base";
-            const string expectedResult = "CREATE DATABASE [Log Data Base]";
+            const string expectedResult = "IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'Log Data Base')\r\nBEGIN\r\nCREATE DATABASE [Log Data Base]\r\nEND\r\n";
             var sut = new SqlCreateDatabaseWriter(databaseName);
 
             // Act


### PR DESCRIPTION
* Fixed #481: do not log exception during auto create db if db already exists
* Throw exceptions during auto create db or table on sink init (related to #478)