### PR TITLE
Truncate additional columns, allow varchar on standard columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ The content of this column is rendered as JSON by default or with a custom IText
 
 ## Custom Property Columns
 
-By default, any log event properties you include in your log statements will be saved to the XML `Properties` column or the JSON `LogEvent` column. But they can also be stored in their own individual columns via the `AdditionalColumns` collection. This adds overhead to write operations but is very useful for frequently-queried properties. Only `ColumnName` is required; the default configuration is `varchar(max)`.
+By default, any log event properties you include in your log statements will be saved to the XML `Properties` column or the JSON `LogEvent` column. But they can also be stored in their own individual columns via the `AdditionalColumns` collection. This adds overhead to write operations but is very useful for frequently-queried properties. Only `ColumnName` is required; the default configuration is `varchar(max)`. If you specify a DataLength on a column of character data types (NVarChar, VarChar, Char, NChar) the string will be automatically truncated to the datalength to fit in the column.
 
 ```csharp
 var columnOptions = new ColumnOptions

--- a/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
@@ -4,6 +4,11 @@ namespace Serilog.Sinks.MSSqlServer.Extensions
 {
     internal static class StringExtensions
     {
+        public static string TruncateOutput(this string value, int dataLength) =>
+            dataLength < 0
+                ? value     // No need to truncate if length set to maximum
+                : value.Truncate(dataLength, "...");
+
         public static string Truncate(this string value, int maxLength, string suffix)
         {
             if (value == null) return null;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ExceptionColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ExceptionColumnOptions.cs
@@ -27,8 +27,8 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.NVarChar)
-                        throw new ArgumentException("The Standard Column \"Exception\" must be NVarChar.");
+                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"Exception\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ExceptionColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ExceptionColumnOptions.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
                         throw new ArgumentException("The Standard Column \"Exception\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
@@ -28,7 +28,7 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value) && value != SqlDbType.TinyInt)
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value) && value != SqlDbType.TinyInt)
                         throw new ArgumentException("The Standard Column \"Level\" must be of data type NVarChar, VarChar or TinyInt.");
                     base.DataType = value;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
@@ -28,8 +28,8 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.NVarChar && value != SqlDbType.TinyInt)
-                        throw new ArgumentException("The Standard Column \"Level\" must be of data type NVarChar or TinyInt.");
+                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value) && value != SqlDbType.TinyInt)
+                        throw new ArgumentException("The Standard Column \"Level\" must be of data type NVarChar, VarChar or TinyInt.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LogEventColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LogEventColumnOptions.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
                         throw new ArgumentException("The Standard Column \"LogEvent\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LogEventColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LogEventColumnOptions.cs
@@ -27,8 +27,8 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.NVarChar)
-                        throw new ArgumentException("The Standard Column \"LogEvent\" must be NVarChar.");
+                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"LogEvent\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageColumnOptions.cs
@@ -27,8 +27,8 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.NVarChar)
-                        throw new ArgumentException("The Standard Column \"Message\" must be NVarChar.");
+                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"Message\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageColumnOptions.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
                         throw new ArgumentException("The Standard Column \"Message\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageTemplateColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageTemplateColumnOptions.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
                         throw new ArgumentException("The Standard Column \"MessageTemplate\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageTemplateColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/MessageTemplateColumnOptions.cs
@@ -27,8 +27,8 @@ namespace Serilog.Sinks.MSSqlServer
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.NVarChar)
-                        throw new ArgumentException("The Standard Column \"MessageTemplate\" must be NVarChar.");
+                    if (!SqlDataTypes.VariableCharactorColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"MessageTemplate\" must be NVarChar or VarChar.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/AdditionalColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/AdditionalColumnDataGenerator.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             {
                 if (SqlDataTypes.DataLengthRequired.Contains(additionalColumn.DataType))
                 {
-                    return new KeyValuePair<string, object>(columnName, TruncateOutput((string)scalarValue.Value, additionalColumn.DataLength));
+                    return new KeyValuePair<string, object>(columnName, scalarValue.Value.ToString().TruncateOutput(additionalColumn.DataLength));
 
                 }
                 return new KeyValuePair<string, object>(columnName, scalarValue.Value);
@@ -60,14 +60,12 @@ namespace Serilog.Sinks.MSSqlServer.Output
             }
             else
             {
-                return new KeyValuePair<string, object>(columnName, DBNull.Value);
+                if (additionalColumn.AllowNull) {
+                    return new KeyValuePair<string, object>(columnName, DBNull.Value);
+                }
+                return new KeyValuePair<string, object>(columnName, property.Value.ToString());
             }
         }
-
-        private static string TruncateOutput(string value, int dataLength) =>
-            dataLength < 0
-                ? value     // No need to truncate if length set to maximum
-                : value.Truncate(dataLength, string.Empty);
 
         private static bool TryChangeType(object obj, Type type, out object conversion)
         {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -45,15 +45,15 @@ namespace Serilog.Sinks.MSSqlServer.Output
             switch (column)
             {
                 case StandardColumn.Message:
-                    return new KeyValuePair<string, object>(_columnOptions.Message.ColumnName, TruncateOutput(logEvent.RenderMessage(_formatProvider), _columnOptions.Message.DataLength));
+                    return new KeyValuePair<string, object>(_columnOptions.Message.ColumnName, logEvent.RenderMessage(_formatProvider).TruncateOutput(_columnOptions.Message.DataLength));
                 case StandardColumn.MessageTemplate:
-                    return new KeyValuePair<string, object>(_columnOptions.MessageTemplate.ColumnName, TruncateOutput(logEvent.MessageTemplate.Text, _columnOptions.MessageTemplate.DataLength));
+                    return new KeyValuePair<string, object>(_columnOptions.MessageTemplate.ColumnName, logEvent.MessageTemplate.Text.TruncateOutput(_columnOptions.MessageTemplate.DataLength));
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:
-                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, TruncateOutput(logEvent.Exception?.ToString(), _columnOptions.Exception.DataLength));
+                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, logEvent.Exception?.ToString().TruncateOutput(_columnOptions.Exception.DataLength));
                 case StandardColumn.Properties:
                     return new KeyValuePair<string, object>(_columnOptions.Properties.ColumnName, ConvertPropertiesToXmlStructure(logEvent.Properties));
                 case StandardColumn.LogEvent:
@@ -62,11 +62,6 @@ namespace Serilog.Sinks.MSSqlServer.Output
                     throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
-
-        private static string TruncateOutput(string value, int dataLength) =>
-            dataLength < 0
-                ? value     // No need to truncate if length set to maximum
-                : value.Truncate(dataLength, "...");
 
         private KeyValuePair<string, object> GetTimeStampStandardColumnNameAndValue(LogEvent logEvent)
         {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// <summary>
         /// SQL column types for supported strings
         /// </summary>
-        public static readonly ReadOnlyCollection<SqlDbType> VariableCharacterColumnTypes = new(new[] {
+        public static readonly ReadOnlyCollection<SqlDbType> VariableCharacterColumnTypes = new ReadOnlyCollection<SqlDbType>(new List<SqlDbType> {
             SqlDbType.NVarChar,
             SqlDbType.VarChar
         });

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
@@ -52,6 +52,15 @@ namespace Serilog.Sinks.MSSqlServer
         };
 
         /// <summary>
+        /// SQL column types for supported strings
+        /// </summary>
+        public static readonly HashSet<SqlDbType> VariableCharactorColumnTypes = new HashSet<SqlDbType>
+        {
+            SqlDbType.NVarChar,
+            SqlDbType.VarChar
+        };
+
+        /// <summary>
         /// The SQL column types which require a non-zero DataLength property.
         /// </summary>
         public static readonly List<SqlDbType> DataLengthRequired = new List<SqlDbType>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Data;
 
 namespace Serilog.Sinks.MSSqlServer
@@ -54,11 +55,10 @@ namespace Serilog.Sinks.MSSqlServer
         /// <summary>
         /// SQL column types for supported strings
         /// </summary>
-        public static readonly HashSet<SqlDbType> VariableCharactorColumnTypes = new HashSet<SqlDbType>
-        {
+        public static readonly ReadOnlyCollection<SqlDbType> VariableCharacterColumnTypes = new(new[] {
             SqlDbType.NVarChar,
             SqlDbType.VarChar
-        };
+        });
 
         /// <summary>
         /// The SQL column types which require a non-zero DataLength property.

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Misc/SqlTypesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Misc/SqlTypesTests.cs
@@ -108,9 +108,12 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Misc
             Log.Information("NVarChar {NVarChar}", twentyChars);
             Log.Information("VarChar {VarChar}", twentyChars);
 
-            // should throw truncation exception
+            // should truncate but not throw
 
-            Assert.Throws<AggregateException>(() => Log.Information("Char {Char}", thirtyChars));
+            Log.Information("Char {Char}", thirtyChars);
+            Log.Information("NChar {NChar}", thirtyChars);
+            Log.Information("NVarChar {NVarChar}", thirtyChars);
+            Log.Information("VarChar {VarChar}", thirtyChars);
 
             Log.CloseAndFlush();
         }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/AdditionalColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/AdditionalColumnDataGeneratorTests.cs
@@ -200,7 +200,7 @@ namespace Serilog.Tests.Output
             // Assert
             _columnSimplePropertyValueResolver.Verify(r => r.GetPropertyValueForColumn(additionalColumn, properties), Times.Once);
             Assert.Equal(columnName, result.Key);
-            Assert.Equal("Additional", result.Value);
+            Assert.Equal("Additio...", result.Value);
         }
     }
 }


### PR DESCRIPTION
Fix for #489 & #436 

Allows setting varchar for standard columns of string types. 
Auto-truncate string type additional columns to the datalength