### PR TITLE
Added OpenTelemetry TraceId and SpanId

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ dev, main ]
 
+  # Run every biweekly to discover failures due to environment changes
+  schedule:
+    - cron: '0 0 1,15 * *'
+  
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="Serilog" Version="2.12.0" />
+    <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageVersion Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />

--- a/README.md
+++ b/README.md
@@ -406,9 +406,11 @@ By default (and consistent with the SQL DDL to create a table shown earlier) the
  - `StandardColumn.Exception`
  - `StandardColumn.Properties`
 
-There is one additional Standard Column which is not included by default (for backwards-compatibility reasons):
+There are the following additional standard columns which are not included by default (for backwards-compatibility reasons):
 
 - `StandardColumn.LogEvent`
+- `StandardColumn.TraceId`
+- `StandardColumn.SpanId`
 
 You can change this list as long as the underlying table definition is consistent:
 
@@ -416,8 +418,10 @@ You can change this list as long as the underlying table definition is consisten
 // we don't need XML data
 columnOptions.Store.Remove(StandardColumn.Properties);
 
-// we do want JSON data
+// we do want JSON data and OpenTelemetry
 columnOptions.Store.Add(StandardColumn.LogEvent);
+columnOptions.Store.Add(StandardColumn.TraceId);
+columnOptions.Store.Add(StandardColumn.SpanId);
 ```
 
 In addition to any special properties described below, each Standard Column also has the usual column properties like `ColumnName` as described in the topic [SqlColumn Objects](#sqlcolumn-objects).
@@ -454,7 +458,7 @@ In case `DataLength` is set to a specific value different from -1, any message l
 
 This column stores the log event message with the property placeholders. It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
 
-If `DataLength` is set to a value different to -1 longer text will be truncated. See [Message column](#message ) for details.
+If `DataLength` is set to a value different to -1 longer text will be truncated. See [Message column](#message) for details.
 
 ### Level
 
@@ -506,9 +510,15 @@ If `OmitElementIfEmpty` is set then if a property is empty, it will not be seria
 
 This column stores log event property values as JSON. Typically you will use either this column or the XML-based `Properties` column, but not both. This column's `DataType` must always be `nvarchar`.
 
-The `ExcludeAddtionalProperties` and `ExcludeStandardColumns` properties are described in the [Custom Property Columns](#custom-property-columns) topic.
+By default this column is not used unless it is added to the `ColumnOptions.Store` property as documented [above](#standard-columns).
 
 The content of this column is rendered as JSON by default or with a custom ITextFormatter passed by the caller as parameter `logEventFormatter`. Details can be found in [Sink Configuration](#sink-configuration).
+
+### TraceId and SpanId
+
+These two columns store the OpenTelemetry `TraceId` and `SpanId` log event properties which are documented [here](https://github.com/serilog/serilog/issues/1923). The `DataType` of these columns must be `nvarchar` or `varchar`.
+
+By default these columns are not used unless they are added to the `ColumnOptions.Store` property as documented [above](#standard-columns).
 
 ## Custom Property Columns
 
@@ -604,7 +614,7 @@ As the name suggests, `columnOptionSection` is an entire configuration section i
     "disableTriggers": true,
     "clusteredColumnstoreIndex": false,
     "primaryKeyColumnName": "Id",
-    "addStandardColumns": [ "LogEvent" ],
+    "addStandardColumns": [ "LogEvent", "TraceId", "SpanId" ],
     "removeStandardColumns": [ "MessageTemplate", "Properties" ],
     "additionalColumns": [
         { "ColumnName": "EventType", "DataType": "int", "AllowNull": false },
@@ -668,6 +678,8 @@ Keys and values are case-sensitive. Case must match **_exactly_** as shown below
     <!-- ColumnOptions parameters -->
     <AddStandardColumns>
         <add Name="LogEvent"/>
+        <add Name="TraceId"/>
+        <add Name="SpanId"/>
     </AddStandardColumns>
     <RemoveStandardColumns>
         <remove Name="Properties"/>

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ In case `DataLength` is set to a specific value different from -1, any message l
 
 This column stores the log event message with the property placeholders. It defaults to `nvarchar(max)`. The `DataType` property can only be set to character-storage types.
 
-In case `DataLength` is set to a specific value different from -1, any template text longer than that length will be effectively truncated to that size. Any truncating ignores all differences between the tokens in the template meaning that a template might get cut off in the middle of a property token. Example: `DataLength` is set to 20 and the message template is "a long {NumberOfCharacters} template text" (without the quotes), the final template stored in the database will be: "a long {NumberOfC..." (again without quotes).
+If `DataLength` is set to a value different to -1 longer text will be truncated. See [Message column](#message ) for details.
 
 ### Level
 
@@ -484,7 +484,7 @@ When the `ConvertToUtc` property is set to `true`, the time stamp is adjusted to
 
 When an exception is logged as part of the log event, the exception message is stored here automatically. The `DataType` must be `nvarchar`.
 
-Similar to the columns `Message` and `MessageTemplate`, setting `DataLength` of `Exception` to a specific value different from -1 will effectively truncate any exception message to the stated length in `DataLength`.
+Similar to the columns `Message` and `MessageTemplate`, setting `DataLength` to a specific value different from -1 will effectively truncate any exception message to the stated length in `DataLength`. See [Message column](#message ) for details.
 
 ### Properties
 
@@ -512,7 +512,10 @@ The content of this column is rendered as JSON by default or with a custom IText
 
 ## Custom Property Columns
 
-By default, any log event properties you include in your log statements will be saved to the XML `Properties` column or the JSON `LogEvent` column. But they can also be stored in their own individual columns via the `AdditionalColumns` collection. This adds overhead to write operations but is very useful for frequently-queried properties. Only `ColumnName` is required; the default configuration is `varchar(max)`. If you specify a DataLength on a column of character data types (NVarChar, VarChar, Char, NChar) the string will be automatically truncated to the datalength to fit in the column.
+By default, any log event properties you include in your log statements will be saved to the XML `Properties` column or the JSON `LogEvent` column. But they can also be stored in their own individual columns via the `AdditionalColumns` collection. This adds overhead to write operations but is very useful for frequently-queried properties. Only `ColumnName` is required; the default configuration is `varchar(max)`.
+
+If you specify a DataLength other than -1 on a column of character data types (NVarChar, VarChar, Char, NChar) longer text will be truncated to the specified length. See [Message column](#message ) for details.
+
 
 ```csharp
 var columnOptions = new ColumnOptions

--- a/sample/WorkerServiceDemo/appsettings.json
+++ b/sample/WorkerServiceDemo/appsettings.json
@@ -21,7 +21,7 @@
           },
           "restrictedToMinimumLevel": "Information",
           "columnOptionsSection": {
-            "addStandardColumns": [ "LogEvent" ],
+            "addStandardColumns": [ "LogEvent", "TraceId", "SpanId" ],
             "removeStandardColumns": [ "MessageTemplate", "Properties" ],
             "timeStamp": {
               "columnName": "Timestamp",
@@ -54,10 +54,10 @@
           "sinkOptionsSection": {
             "tableName": "LogEventsAudit",
             "autoCreateSqlDatabase": true,
-            "autoCreateSqlTable": true,
+            "autoCreateSqlTable": true
           },
           "columnOptionsSection": {
-            "addStandardColumns": [ "LogEvent" ],
+            "addStandardColumns": [ "LogEvent", "TraceId", "SpanId" ],
             "removeStandardColumns": [ "MessageTemplate", "Properties" ],
             "timeStamp": {
               "columnName": "Timestamp",

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProvider.cs
@@ -147,6 +147,18 @@ namespace Serilog.Sinks.MSSqlServer.Configuration
             section = config.GetSection("messageTemplate");
             if (section != null)
                 SetCommonColumnOptions(section, columnOptions.MessageTemplate);
+
+            section = config.GetSection("traceId");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.TraceId);
+            }
+
+            section = config.GetSection("spanId");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.SpanId);
+            }
         }
 
         private static void ReadMiscColumnOptions(IConfigurationSection config, ColumnOptions columnOptions)

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
@@ -106,6 +106,18 @@ namespace Serilog.Configuration
             get => (StandardColumnConfigLevel)base[nameof(Level)];
         }
 
+        [ConfigurationProperty(nameof(TraceId))]
+        public StandardColumnConfigTraceId TraceId
+        {
+            get => (StandardColumnConfigTraceId)base[nameof(TraceId)];
+        }
+
+        [ConfigurationProperty(nameof(SpanId))]
+        public StandardColumnConfigSpanId SpanId
+        {
+            get => (StandardColumnConfigSpanId)base[nameof(SpanId)];
+        }
+
         [ConfigurationProperty(nameof(LogEvent))]
         public StandardColumnConfigLogEvent LogEvent
         {

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/StandardColumnConfigSpanId.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/StandardColumnConfigSpanId.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigSpanId : ColumnConfig
+    {
+        public StandardColumnConfigSpanId() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/StandardColumnConfigTraceId.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/StandardColumnConfigTraceId.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigTraceId : ColumnConfig
+    {
+        public StandardColumnConfigTraceId() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProvider.cs
@@ -105,6 +105,8 @@ namespace Serilog.Sinks.MSSqlServer.Configuration
             SetCommonColumnOptions(config.Id, columnOptions.Id);
             SetCommonColumnOptions(config.Level, columnOptions.Level);
             SetCommonColumnOptions(config.LogEvent, columnOptions.LogEvent);
+            SetCommonColumnOptions(config.TraceId, columnOptions.TraceId);
+            SetCommonColumnOptions(config.SpanId, columnOptions.SpanId);
             SetCommonColumnOptions(config.Message, columnOptions.Message);
             SetCommonColumnOptions(config.MessageTemplate, columnOptions.MessageTemplate);
             SetCommonColumnOptions(config.PropertiesColumn, columnOptions.Properties);

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
-    <VersionPrefix>6.4.0</VersionPrefix>
+    <VersionPrefix>6.5.0</VersionPrefix>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net462;net472;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/ColumnOptions.cs
@@ -20,6 +20,8 @@ namespace Serilog.Sinks.MSSqlServer
             // Apply any defaults in the individual Standard Column constructors.
             Id = new IdColumnOptions();
             Level = new LevelColumnOptions();
+            TraceId = new TraceIdColumnOptions();
+            SpanId = new SpanIdColumnOptions();
             Properties = new PropertiesColumnOptions();
             Message = new MessageColumnOptions();
             MessageTemplate = new MessageTemplateColumnOptions();
@@ -114,6 +116,16 @@ namespace Serilog.Sinks.MSSqlServer
         public LevelColumnOptions Level { get; private set; }
 
         /// <summary>
+        /// Options for the TraceId column.
+        /// </summary>
+        public TraceIdColumnOptions TraceId { get; private set; }
+
+        /// <summary>
+        /// Options for the SpanId column.
+        /// </summary>
+        public SpanIdColumnOptions SpanId { get; private set; }
+
+        /// <summary>
         /// Options for the Properties column.
         /// </summary>
         public PropertiesColumnOptions Properties { get; private set; }
@@ -152,6 +164,8 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 case StandardColumn.Id: return Id;
                 case StandardColumn.Level: return Level;
+                case StandardColumn.TraceId: return TraceId;
+                case StandardColumn.SpanId: return SpanId;
                 case StandardColumn.TimeStamp: return TimeStamp;
                 case StandardColumn.LogEvent: return LogEvent;
                 case StandardColumn.Message: return Message;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/SpanIdColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/SpanIdColumnOptions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Data;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public partial class ColumnOptions // Standard Column options are inner classes for backwards-compatibility.
+    {
+        /// <summary>
+        /// Options for the SpanId column.
+        /// </summary>
+        public class SpanIdColumnOptions : SqlColumn
+        {
+            /// <summary>
+            /// Constructor.
+            /// </summary>
+            public SpanIdColumnOptions() : base()
+            {
+                StandardColumnIdentifier = StandardColumn.SpanId;
+                DataType = SqlDbType.NVarChar;
+            }
+
+            /// <summary>
+            /// The SpanId column defaults to NVarChar and must be of a character-storage data type.
+            /// </summary>
+            public new SqlDbType DataType
+            {
+                get => base.DataType;
+                set
+                {
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"SpanId\" must be NVarChar or VarChar.");
+                    base.DataType = value;
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/TraceIdColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/TraceIdColumnOptions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Data;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public partial class ColumnOptions // Standard Column options are inner classes for backwards-compatibility.
+    {
+        /// <summary>
+        /// Options for the TraceId column.
+        /// </summary>
+        public class TraceIdColumnOptions : SqlColumn
+        {
+            /// <summary>
+            /// Constructor.
+            /// </summary>
+            public TraceIdColumnOptions() : base()
+            {
+                StandardColumnIdentifier = StandardColumn.TraceId;
+                DataType = SqlDbType.NVarChar;
+            }
+
+            /// <summary>
+            /// The TraceId column defaults to NVarChar and must be of a character-storage data type.
+            /// </summary>
+            public new SqlDbType DataType
+            {
+                get => base.DataType;
+                set
+                {
+                    if (!SqlDataTypes.VariableCharacterColumnTypes.Contains(value))
+                        throw new ArgumentException("The Standard Column \"TraceId\" must be NVarChar or VarChar.");
+                    base.DataType = value;
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -50,6 +50,10 @@ namespace Serilog.Sinks.MSSqlServer.Output
                     return new KeyValuePair<string, object>(_columnOptions.MessageTemplate.ColumnName, logEvent.MessageTemplate.Text.TruncateOutput(_columnOptions.MessageTemplate.DataLength));
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
+                case StandardColumn.TraceId:
+                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId);
+                case StandardColumn.SpanId:
+                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId);
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
@@ -26,6 +26,16 @@
         Level,
 
         /// <summary>
+        /// The OpenTelemetry trace id of the event.
+        /// </summary>
+        TraceId,
+
+        /// <summary>
+        /// The OpenTelemetry span id of the event.
+        /// </summary>
+        SpanId,
+
+        /// <summary>
         /// The time at which the event occurred.
         /// </summary>
         TimeStamp,

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProviderTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProviderTests.cs
@@ -489,6 +489,44 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsof
         }
 
         [Fact]
+        public void ConfigureColumnOptionsAddsColumnTraceIdWithSpecifiedOptions()
+        {
+            // Arrange
+            const string columnName = "TestColumnName";
+            var dataType = SqlDbType.NVarChar;
+            var allowNull = true;
+            var nonClusteredIndex = true;
+            SetupConfigurationSectionMocks();
+            SetupColumnSectionMock("traceId", columnName, dataType, allowNull, nonClusteredIndex);
+            var sut = new MicrosoftExtensionsColumnOptionsProvider();
+
+            // Act
+            var result = sut.ConfigureColumnOptions(new Serilog.Sinks.MSSqlServer.ColumnOptions(), _configurationSectionMock.Object);
+
+            // Assert
+            AssertColumnSqlOptions(columnName, dataType, allowNull, nonClusteredIndex, result.TraceId);
+        }
+
+        [Fact]
+        public void ConfigureColumnOptionsAddsColumnSpanIdWithSpecifiedOptions()
+        {
+            // Arrange
+            const string columnName = "TestColumnName";
+            var dataType = SqlDbType.NVarChar;
+            var allowNull = true;
+            var nonClusteredIndex = true;
+            SetupConfigurationSectionMocks();
+            SetupColumnSectionMock("spanId", columnName, dataType, allowNull, nonClusteredIndex);
+            var sut = new MicrosoftExtensionsColumnOptionsProvider();
+
+            // Act
+            var result = sut.ConfigureColumnOptions(new Serilog.Sinks.MSSqlServer.ColumnOptions(), _configurationSectionMock.Object);
+
+            // Assert
+            AssertColumnSqlOptions(columnName, dataType, allowNull, nonClusteredIndex, result.SpanId);
+        }
+
+        [Fact]
         public void ConfigureColumnOptionsAddsColumnMessageWithSpecifiedOptions()
         {
             // Arrange

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/StandardColumnConfigSpanIdTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/StandardColumnConfigSpanIdTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Configuration;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.Configuration
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class StandardColumnConfigSpanIdTests
+    {
+        [Fact]
+        public void ClassSetsColumnNameRequiredAttributeToFalse()
+        {
+            var sut = typeof(StandardColumnConfigSpanId);
+            var columNameProperty = sut.GetProperty("ColumnName");
+            var configurationPropertyAttribute = (ConfigurationPropertyAttribute) Attribute.GetCustomAttribute(columNameProperty, typeof(ConfigurationPropertyAttribute));
+
+            Assert.Equal("ColumnName", configurationPropertyAttribute.Name);
+            Assert.False(configurationPropertyAttribute.IsRequired);
+        }
+
+        [Fact]
+        public void ClassSetsColumnNameIsKeyAttributeToTrue()
+        {
+            var sut = typeof(StandardColumnConfigSpanId);
+            var columNameProperty = sut.GetProperty("ColumnName");
+            var configurationPropertyAttribute = (ConfigurationPropertyAttribute)Attribute.GetCustomAttribute(columNameProperty, typeof(ConfigurationPropertyAttribute));
+
+            Assert.Equal("ColumnName", configurationPropertyAttribute.Name);
+            Assert.True(configurationPropertyAttribute.IsKey);
+        }
+
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/StandardColumnConfigTraceIdTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/StandardColumnConfigTraceIdTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Configuration;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.Configuration
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class StandardColumnConfigTraceIdTests
+    {
+        [Fact]
+        public void ClassSetsColumnNameRequiredAttributeToFalse()
+        {
+            // Arrange + act
+            var sut = typeof(StandardColumnConfigTraceId);
+            var columNameProperty = sut.GetProperty("ColumnName");
+            var configurationPropertyAttribute = (ConfigurationPropertyAttribute) Attribute.GetCustomAttribute(columNameProperty, typeof(ConfigurationPropertyAttribute));
+
+            // Assert
+            Assert.Equal("ColumnName", configurationPropertyAttribute.Name);
+            Assert.False(configurationPropertyAttribute.IsRequired);
+        }
+
+        [Fact]
+        public void ClassSetsColumnNameIsKeyAttributeToTrue()
+        {
+            // Arrange + act
+            var sut = typeof(StandardColumnConfigTraceId);
+            var columNameProperty = sut.GetProperty("ColumnName");
+            var configurationPropertyAttribute = (ConfigurationPropertyAttribute)Attribute.GetCustomAttribute(columNameProperty, typeof(ConfigurationPropertyAttribute));
+
+            // Assert
+            Assert.Equal("ColumnName", configurationPropertyAttribute.Name);
+            Assert.True(configurationPropertyAttribute.IsKey);
+        }
+
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProviderTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProviderTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Data;
+using Moq;
+using Serilog.Configuration;
+using Serilog.Sinks.MSSqlServer.Configuration;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.Configuration
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class SystemConfigurationColumnOptionsProviderTests
+    {
+        private readonly MSSqlServerConfigurationSection _configurationSection;
+        private readonly SystemConfigurationColumnOptionsProvider _sut;
+
+        public SystemConfigurationColumnOptionsProviderTests()
+        {
+            _configurationSection = new MSSqlServerConfigurationSection();
+            _sut = new SystemConfigurationColumnOptionsProvider();
+        }
+
+        [Fact]
+        public void ConfigureColumnOptionsReadsTraceIdColumnOptions()
+        {
+            // Arrange
+            const string columnName = "TestColumnName";
+            _configurationSection.TraceId.ColumnName = columnName;
+            _configurationSection.TraceId.AllowNull = "false";
+            _configurationSection.TraceId.DataType = "22"; // VarChar
+            var columnOptions = new MSSqlServer.ColumnOptions();
+            
+            // Act
+            _sut.ConfigureColumnOptions(_configurationSection, columnOptions);
+
+            // Assert
+            Assert.Equal(columnName, columnOptions.TraceId.ColumnName);
+            Assert.False(columnOptions.TraceId.AllowNull);
+            Assert.Equal(SqlDbType.VarChar, columnOptions.TraceId.DataType);
+        }
+
+        [Fact]
+        public void ConfigureColumnOptionsReadsSpanIdColumnOptions()
+        {
+            // Arrange
+            const string columnName = "TestColumnName";
+            _configurationSection.SpanId.ColumnName = columnName;
+            _configurationSection.SpanId.AllowNull = "false";
+            _configurationSection.SpanId.DataType = "22"; // VarChar
+            var columnOptions = new MSSqlServer.ColumnOptions();
+
+            // Act
+            _sut.ConfigureColumnOptions(_configurationSection, columnOptions);
+
+            // Assert
+            Assert.Equal(columnName, columnOptions.SpanId.ColumnName);
+            Assert.False(columnOptions.SpanId.AllowNull);
+            Assert.Equal(SqlDbType.VarChar, columnOptions.SpanId.DataType);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Misc/OpenTelemetryColumnsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Misc/OpenTelemetryColumnsTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Misc
+{
+    [Trait(TestCategory.TraitName, TestCategory.Integration)]
+    public class OpenTelemetryColumnsTests : DatabaseTestsBase
+    {
+        public OpenTelemetryColumnsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void OpenTelemetryActivityTraceIdAndSpanIdAreStoredInColumns()
+        {
+            // Arrange
+            var expectedTraceId = string.Empty;
+            var expectedSpanId = string.Empty;
+            var columnOptions = new MSSqlServer.ColumnOptions();
+            columnOptions.Store.Add(StandardColumn.TraceId);
+            columnOptions.Store.Add(StandardColumn.SpanId);
+
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.MSSqlServer
+                (
+                    connectionString: DatabaseFixture.LogEventsConnectionString,
+                    new MSSqlServerSinkOptions
+                    {
+                        TableName = DatabaseFixture.LogTableName,
+                        AutoCreateSqlTable = true
+                    },
+                    columnOptions: columnOptions,
+                    formatProvider: CultureInfo.InvariantCulture
+                )
+                .CreateLogger();
+
+            // Act
+            using (var testActivity = new Activity("OpenTelemetryColumnsTests"))
+            {
+                testActivity.SetIdFormat(ActivityIdFormat.W3C);
+                testActivity.Start();
+                expectedTraceId = testActivity.TraceId.ToString();
+                expectedSpanId = testActivity.SpanId.ToString();
+
+
+                Log.Logger.Information("Logging message");
+                Log.CloseAndFlush();
+            }
+
+            // Assert
+            VerifyStringColumnWritten("TraceId", expectedTraceId);
+            VerifyStringColumnWritten("SpanId", expectedSpanId);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/ColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/ColumnOptionsTests.cs
@@ -1,0 +1,35 @@
+﻿using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.ColumnOptions
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class ColumnOptionsTests
+    {
+        [Fact]
+        public void GetStandardColumnOptionsReturnsTraceIdOptions()
+        {
+            // Arrange
+            var sut = new MSSqlServer.ColumnOptions();
+
+            // Act
+            var result = sut.GetStandardColumnOptions(StandardColumn.TraceId);
+
+            // Assert
+            Assert.Same(sut.TraceId, result);
+        }
+
+        [Fact]
+        public void GetStandardColumnOptionsReturnsSpanIdOptions()
+        {
+            // Arrange
+            var sut = new MSSqlServer.ColumnOptions();
+
+            // Act
+            var result = sut.GetStandardColumnOptions(StandardColumn.SpanId);
+
+            // Assert
+            Assert.Same(sut.SpanId, result);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/SpanIdColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/SpanIdColumnOptionsTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Data;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.ColumnOptions
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class SpanIdColumnOptionsTests
+    {
+        [Fact]
+        public void CanSetDataTypeNVarChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act - should not throw
+            options.SpanId.DataType = SqlDbType.NVarChar;
+        }
+
+        [Fact]
+        public void CanSetDataTypeVarChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act - should not throw
+            options.SpanId.DataType = SqlDbType.VarChar;
+        }
+
+        [Fact]
+        public void CannotSetDataTypeBigInt()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act and assert - should throw
+            Assert.Throws<ArgumentException>(() => options.SpanId.DataType = SqlDbType.BigInt);
+        }
+
+        [Fact]
+        public void CannotSetDataTypeNChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act and assert - should throw
+            Assert.Throws<ArgumentException>(() => options.SpanId.DataType = SqlDbType.NChar);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TraceIdColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TraceIdColumnOptionsTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Data;
+using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.ColumnOptions
+{
+    [Trait(TestCategory.TraitName, TestCategory.Unit)]
+    public class TraceIdColumnOptionsTests
+    {
+        [Fact]
+        public void CanSetDataTypeNVarChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act - should not throw
+            options.TraceId.DataType = SqlDbType.NVarChar;
+        }
+
+        [Fact]
+        public void CanSetDataTypeVarChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act - should not throw
+            options.TraceId.DataType = SqlDbType.VarChar;
+        }
+
+        [Fact]
+        public void CannotSetDataTypeBigInt()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act and assert - should throw
+            Assert.Throws<ArgumentException>(() => options.TraceId.DataType = SqlDbType.BigInt);
+        }
+
+        [Fact]
+        public void CannotSetDataTypeNChar()
+        {
+            // Arrange
+            var options = new MSSqlServer.ColumnOptions();
+
+            // Act and assert - should throw
+            Assert.Throws<ArgumentException>(() => options.TraceId.DataType = SqlDbType.NChar);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using Moq;
@@ -260,6 +261,44 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             // Assert
             Assert.Equal("Level", result.Key);
             Assert.Equal(expectedValue, result.Value);
+        }
+
+        [Fact]
+        public void GetStandardColumnNameAndValueForTraceIdReturnsLogLevelKeyValue()
+        {
+            // Arrange
+            var traceId = ActivityTraceId.CreateFromString("34898a9020e0390190b0982370034f00".AsSpan());
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), traceId, ActivitySpanId.CreateRandom());
+            SetupSut(new MSSqlServer.ColumnOptions(), CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.TraceId, logEvent);
+
+            // Assert
+            Assert.Equal("TraceId", result.Key);
+            Assert.Equal(traceId, result.Value);
+        }
+
+        [Fact]
+        public void GetStandardColumnNameAndValueForSpanIdReturnsLogLevelKeyValue()
+        {
+            // Arrange
+            var spanId = ActivitySpanId.CreateFromString("0390190b09823700".AsSpan());
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), ActivityTraceId.CreateRandom(), spanId);
+            SetupSut(new MSSqlServer.ColumnOptions(), CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.SpanId, logEvent);
+
+            // Assert
+            Assert.Equal("SpanId", result.Key);
+            Assert.Equal(spanId, result.Value);
         }
 
         [Fact]


### PR DESCRIPTION
Added the new standard columns TraceId and SpanId for OpenTelemetry tracing. Those columns are by default not enabled and must be added to the ColumnOptions.Store property to use them (for backwards compatibility). If the columns are activated, the corresponding OpenTracing log event properties from Serilog will be written to those columns (https://github.com/serilog/serilog/pull/1955).