### PR TITLE
Fixed a string truncate bug

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Extensions/StringExtensions.cs
@@ -12,11 +12,13 @@ namespace Serilog.Sinks.MSSqlServer.Extensions
         public static string Truncate(this string value, int maxLength, string suffix)
         {
             if (value == null) return null;
+            else if (value.Length <= maxLength) return value;
+
             var suffixLength = suffix?.Length ?? 0;
             if (maxLength <= suffixLength) return string.Empty;
 
             var correctedMaxLength = maxLength - suffixLength;
-            return value.Length <= maxLength ? value : Invariant($"{value.Substring(0, correctedMaxLength)}{suffix}");
+            return Invariant($"{value.Substring(0, correctedMaxLength)}{suffix}");
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Extensions/StringExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Extensions/StringExtensionsTests.cs
@@ -62,6 +62,20 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Extensions
             Assert.Equal("A simple tes...", truncatedMessage);
         }
 
+        [Theory]
+        [InlineData("Abc")]
+        [InlineData("Ab")]
+        [InlineData("X")]
+        [Trait("Bugfix", "#505")]
+        public void ReturnNonTruncatedShortStringWhenMaxLengthIsLessOrEqualToSuffixLength(string inputMessage)
+        {
+            // Act
+            var nonTruncatedMessage = inputMessage.Truncate(3, "...");
+
+            // Assert
+            Assert.Equal(inputMessage, nonTruncatedMessage);
+        }
+
         [Fact]
         public void ReturnTruncatedStringWithEmptySuffix()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/AdditionalColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/AdditionalColumnDataGeneratorTests.cs
@@ -202,5 +202,28 @@ namespace Serilog.Tests.Output
             Assert.Equal(columnName, result.Key);
             Assert.Equal("Additio...", result.Value);
         }
+
+        [Fact]
+        [Trait("Bugfix", "#505")]
+        public void GetAdditionalColumnNameAndValueReturnsFullStringWithOneDataLength()
+        {
+            // Arrange
+            const string columnName = "AdditionalProperty1";
+            const string propertyValue = "A";
+            var additionalColumn = new SqlColumn(columnName, SqlDbType.NVarChar);
+            additionalColumn.DataLength = 1;
+            var properties = new Dictionary<string, LogEventPropertyValue>();
+            _columnSimplePropertyValueResolver.Setup(r => r.GetPropertyValueForColumn(
+                It.IsAny<SqlColumn>(), It.IsAny<IReadOnlyDictionary<string, LogEventPropertyValue>>()))
+                .Returns(new KeyValuePair<string, LogEventPropertyValue>(columnName, new ScalarValue(propertyValue)));
+
+            // Act
+            var result = _sut.GetAdditionalColumnNameAndValue(additionalColumn, properties);
+
+            // Assert
+            _columnSimplePropertyValueResolver.Verify(r => r.GetPropertyValueForColumn(additionalColumn, properties), Times.Once);
+            Assert.Equal(columnName, result.Key);
+            Assert.Equal(propertyValue, result.Value);
+        }
     }
 }


### PR DESCRIPTION
Added a fix for a bug introduced in v6.4.0 where NVarChar columns with a data length of 1 would always end up as an empty string inside the database.

Fixes #505