### PR TITLE
Fixed bug #515

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -51,9 +51,9 @@ namespace Serilog.Sinks.MSSqlServer.Output
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
                 case StandardColumn.TraceId:
-                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId);
+                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId.ToString());
                 case StandardColumn.SpanId:
-                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId);
+                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId.ToString());
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -279,7 +279,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
 
             // Assert
             Assert.Equal("TraceId", result.Key);
-            Assert.Equal(traceId, result.Value);
+            Assert.Equal("34898a9020e0390190b0982370034f00", result.Value);
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
 
             // Assert
             Assert.Equal("SpanId", result.Key);
-            Assert.Equal(spanId, result.Value);
+            Assert.Equal("0390190b09823700", result.Value);
         }
 
         [Fact]


### PR DESCRIPTION
When include 2 standard columns SpanId and TraceId, AuditTo() will throw an exception. The quick solution is adding ToString() for these columns in the function GetStandardColumnNameAndValue
Fix #515 