### PR TITLE
Enabled NuGet audit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 6.7.1
+* Fixed issue #552 by downgrading SqlClient dependency to 5.1.6 which is LTS and fixed the vulnerabilities referenced in issue #544
+* Fixed vulnerabilities by removing all System.* 4 versions as recommended by Microsoft (https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/#system-net-http-and-system-text-regularexpressions, issue #544)
+* Fixed vulnerability by updating xunit to 2.9.0 (issue #544)
+* Fixed vulnerability by directly referencing transitive dependency System.Formats.Asn1 (https://github.com/advisories/GHSA-447r-wph3-92pm, issue #544)
+* Fixed vulnerability by directly referencing transitive dependency System.Private.Uri (https://github.com/advisories/GHSA-xhfc-gr8f-ffwc, issue #544)
+* Activated NuGet Audit for high and critical vulnerabilities in direct and transitive dependencies for all projects (https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/)
+
 # 6.7.0
 * Fixed some of the vulnerabilities referenced in issue #544 by updating SqlClient dependency to 5.2.1
 * Update codeql-action to v3 before deprecation

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+        <NuGetAuditMode>all</NuGetAuditMode>
+        <NuGetAuditLevel>high</NuGetAuditLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,26 +1,27 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+        <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
-    <PackageVersion Include="Dapper.StrongName" Version="2.0.123" />
-    <PackageVersion Include="Moq" Version="4.18.2" />
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+        <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+        <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+        <PackageVersion Include="Dapper.StrongName" Version="2.0.123" />
+        <PackageVersion Include="Moq" Version="4.18.2" />
         <PackageVersion Include="xunit" Version="2.9.0" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Serilog" Version="3.1.1" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />
-    <PackageVersion Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
-  </ItemGroup>
+        <PackageVersion Include="Serilog" Version="3.1.1" />
+        <PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+        <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />
+        <PackageVersion Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+    </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,12 +5,6 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageVersion Include="System.Collections" Version="4.3.0" />
-    <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageVersion Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageVersion Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Dapper.StrongName" Version="2.0.123" />
     <PackageVersion Include="Moq" Version="4.18.2" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageVersion Include="xunit" Version="2.9.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/serilog-sinks-mssqlserver.sln
+++ b/serilog-sinks-mssqlserver.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Build.ps1 = Build.ps1
 		CHANGES.md = CHANGES.md
+		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\workflows\pr-analysis-codeql.yml = .github\workflows\pr-analysis-codeql.yml

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -38,6 +38,8 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" />
+    <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -38,8 +38,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System" />
-    <Reference Include="System.Transactions" />
     <Reference Include="Microsoft.CSharp" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
@@ -47,12 +45,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="System.Collections" />
-    <PackageReference Include="System.Runtime.InteropServices" />
-    <PackageReference Include="System.Runtime.Extensions" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" />
-    <PackageReference Include="System.Resources.ResourceManager" />
-    <PackageReference Include="System.Text.Encoding.Extensions" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
@@ -162,7 +162,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                  });
 
             // Act
-            await _sut.EmitBatchAsync(logEvents).ConfigureAwait(false);
+            await _sut.EmitBatchAsync(logEvents);
 
             // Assert
             _sqlBulkBatchWriter.Verify(w => w.WriteBatch(It.IsAny<IEnumerable<LogEvent>>(), _dataTable), Times.Once);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlBulkBatchWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlBulkBatchWriterTests.cs
@@ -72,7 +72,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _logEventDataGeneratorMock.Verify(c => c.GetColumnsAndValues(logEvents[0]), Times.Once);
@@ -86,7 +86,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlConnectionFactoryMock.Verify(f => f.Create(), Times.Once);
@@ -99,7 +99,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlConnectionWrapperMock.Verify(c => c.OpenAsync(), Times.Once);
@@ -113,7 +113,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var expectedDestinationTableName = string.Format(CultureInfo.InvariantCulture, "[{0}].[{1}]", _schemaName, _tableName);
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlConnectionWrapperMock.Verify(c => c.CreateSqlBulkCopy(false, expectedDestinationTableName), Times.Once);
@@ -128,7 +128,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var sut = new SqlBulkBatchWriter(_tableName, _schemaName, true, _sqlConnectionFactoryMock.Object, _logEventDataGeneratorMock.Object);
 
             // Act
-            await sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlConnectionWrapperMock.Verify(c => c.CreateSqlBulkCopy(true, expectedDestinationTableName), Times.Once);
@@ -145,7 +145,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             _dataTable.Columns.Add(new DataColumn(column2Name));
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlBulkCopyWrapper.Verify(c => c.AddSqlBulkCopyColumnMapping(column1Name, column1Name), Times.Once);
@@ -159,7 +159,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             _sqlBulkCopyWrapper.Verify(c => c.WriteToServerAsync(_dataTable), Times.Once);
@@ -172,14 +172,14 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents, _dataTable).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents, _dataTable);
 
             // Assert
             Assert.Empty(_dataTable.Rows);
         }
 
         [Fact]
-        public void WriteBatchRethrowsIfLogEventDataGeneratorMockGetColumnsAndValuesThrows()
+        public async Task WriteBatchRethrowsIfLogEventDataGeneratorMockGetColumnsAndValuesThrows()
         {
             // Arrange
             _logEventDataGeneratorMock.Setup(d => d.GetColumnsAndValues(It.IsAny<LogEvent>()))
@@ -187,33 +187,33 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act + assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
         }
 
         [Fact]
-        public void WriteBatchRethrowsIfSqlConnectionFactoryCreateThrows()
+        public async Task WriteBatchRethrowsIfSqlConnectionFactoryCreateThrows()
         {
             // Arrange
             _sqlConnectionFactoryMock.Setup(f => f.Create()).Callback(() => throw new InvalidOperationException());
             var logEvents = CreateLogEvents();
 
             // Act + assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
         }
 
         [Fact]
-        public void WriteBatchRethrowsIfSqlConnectionOpenAsyncThrows()
+        public async Task WriteBatchRethrowsIfSqlConnectionOpenAsyncThrows()
         {
             // Arrange
             _sqlConnectionWrapperMock.Setup(c => c.OpenAsync()).Callback(() => throw new InvalidOperationException());
             var logEvents = CreateLogEvents();
 
             // Act + assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
         }
 
         [Fact]
-        public void WriteBatchRethrowsIfSqlBulkCopyWriterAddSqlBulkCopyColumnMappingThrows()
+        public async Task WriteBatchRethrowsIfSqlBulkCopyWriterAddSqlBulkCopyColumnMappingThrows()
         {
             // Arrange
             _sqlBulkCopyWrapper.Setup(c => c.AddSqlBulkCopyColumnMapping(It.IsAny<string>(), It.IsAny<string>()))
@@ -222,11 +222,11 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             _dataTable.Columns.Add(new DataColumn("ColumnName"));
 
             // Act + assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
         }
 
         [Fact]
-        public void WriteBatchRethrowsIfSqlBulkCopyWriterWriteToServerAsyncThrows()
+        public async Task WriteBatchRethrowsIfSqlBulkCopyWriterWriteToServerAsyncThrows()
         {
             // Arrange
             _sqlBulkCopyWrapper.Setup(c => c.WriteToServerAsync(It.IsAny<DataTable>()))
@@ -234,7 +234,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act + assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.WriteBatch(logEvents, _dataTable));
         }
 
         private static List<LogEvent> CreateLogEvents()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlInsertStatementWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlInsertStatementWriterTests.cs
@@ -192,7 +192,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             var logEvents = CreateLogEvents();
 
             // Act
-            await _sut.WriteBatch(logEvents).ConfigureAwait(false);
+            await _sut.WriteBatch(logEvents);
 
             // Assert
             _logEventDataGeneratorMock.Verify(c => c.GetColumnsAndValues(logEvents[0]), Times.Once);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/SqlServerColumnTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/SqlServerColumnTests.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
             // Assert
             Assert.Equal(propertyName, sut.PropertyName);
-            Assert.Equal(1, sut.PropertyNameHierarchy.Count);
+            Assert.Single(sut.PropertyNameHierarchy);
             Assert.Equal(propertyName, sut.PropertyNameHierarchy[0]);
             Assert.False(sut.HasHierarchicalPropertyName);
         }


### PR DESCRIPTION
Fixed vulnerabilites from #544 and package downgrade from #552

* Fixed issue #552 by downgrading SqlClient dependency to 5.1.6 which is LTS and fixed the vulnerabilities referenced in issue #544
* Fixed vulnerabilities by removing all System.* 4 versions as recommended by Microsoft (https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/#system-net-http-and-system-text-regularexpressions, issue #544)
* Fixed vulnerability by updating xunit to 2.9.0 (issue #544)
* Fixed vulnerability by directly referencing transitive dependency System.Formats.Asn1 (https://github.com/advisories/GHSA-447r-wph3-92pm, issue #544)
* Fixed vulnerability by directly referencing transitive dependency System.Private.Uri (https://github.com/advisories/GHSA-xhfc-gr8f-ffwc, issue #544)
* Activated NuGet Audit for high and critical vulnerabilities in direct and transitive dependencies for all projects (https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/)
