### PR TITLE
Release build on Windows for .NET Framework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest # Build on Windows to ensure .NET Framework targets
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Run build in release.yml again in on windows-latest agent to fix a problem with the .NET Framework binaries in the nuget package as described in #567.