### PR TITLE
Fixed issue #541 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ CREATE TABLE [Logs] (
    [Message] nvarchar(max) NULL,
    [MessageTemplate] nvarchar(max) NULL,
    [Level] nvarchar(max) NULL,
-   [TimeStamp] datetime NOT NULL,
+   [TimeStamp] datetime NULL,
    [Exception] nvarchar(max) NULL,
    [Properties] nvarchar(max) NULL
 


### PR DESCRIPTION
The Timestamp column is nullable by default but the README.md stated the opposite. This was fixed now.