### PR TITLE
Implemented #542: Column option ResolveHierarchicalPropertyName to force non-hierarchical handling

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -71,13 +71,17 @@ try
         {
             Push-Location "$testProjectPath"
 
-            echo "build: Testing project in $testProjectPath"
-            & dotnet test -c Release --collect "XPlat Code Coverage"
-            if ($LASTEXITCODE -ne 0)
+            # Run tests for different targets in sequence to avoid database tests
+            # to fail because of concurrency problems
+            foreach ($tfm in @( "net462", "net472", "net8.0" ))
             {
-                exit 2
+                echo "build: Testing project in $testProjectPath for target $tfm"
+                & dotnet test -c Release --collect "XPlat Code Coverage" --framework "$tfm" --results-directory "./TestResults/$tfm"
+                if ($LASTEXITCODE -ne 0)
+                {
+                    exit 2
+                }
             }
-
         }
         finally
         {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 8.1.0
+* Implemented #542: Column option `ResolveHierarchicalPropertyName` to force non-hierarchical handling
+
 # 8.0.1
 * Refactoring and performance optimizations in batched and audit sink
 * Create perftest result on release

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Each Standard Column in the `ColumnOptions.Store` list and any custom columns yo
 
 * `ColumnName`
 * `PropertyName`
+* `ResolveHierarchicalPropertyName`
 * `DataType`
 * `AllowNull`
 * `DataLength`
@@ -352,7 +353,11 @@ Any valid SQL column name can be used. Standard Columns have default names assig
 
 The optional name of a Serilog property to use as the value for a custom column. If not provided, the property used is the one that has the same name as the specified ColumnName. It applies only to custom columns defined in `AdditionalColumns` and is ignored for standard columns.
 
-PropertyName can contain a simple property name like `SomeProperty` but it can also be used to hierachically reference sub-properties with expressions like `SomeProperty.SomeSubProperty.SomeThirdLevelProperty`. This can be used to easily bind additional columns to specific sub-properties following the paradigm of structured logging. Please be aware that collections are not supported. This means expressions like `SomeProperty.SomeArray[2]` will not work.
+PropertyName can contain a simple property name like `SomeProperty` but it can also be used to hierarchically reference sub-properties with expressions like `SomeProperty.SomeSubProperty.SomeThirdLevelProperty`. This can be used to easily bind additional columns to specific sub-properties following the paradigm of structured logging. Please be aware that collections are not supported. This means expressions like `SomeProperty.SomeArray[2]` will not work. Hierarchical property resolution can be disabled using `ResolveHierarchicalPropertyName` in case you need property names containing dots which should not be treated as hierarchical.
+
+### ResolveHierarchicalPropertyName
+
+Controls whether hierarchical sub-property expressions in `PropertyName` are evaluated (see above). The default is `true`. If set to `false` any value is treated as a simple property name and no hierarchical sub-property binding is done.
 
 ### DataType
 
@@ -385,7 +390,7 @@ Numeric types use the default precision and scale. For numeric types, you are re
 
 ### AllowNull
 
-Determines whether or not the column can store SQL `NULL` values. The default is true. Some of the other features like `PrimaryKey` have related restrictions, and some of the Standard Columns impose restrictions (for example, the `Id` column never allows nulls).
+Determines whether the column can store SQL `NULL` values. The default is `true`. Some of the other features like `PrimaryKey` have related restrictions, and some of the Standard Columns impose restrictions (for example, the `Id` column never allows nulls).
 
 ### DataLength
 

--- a/sample/WorkerServiceDemo/Worker.cs
+++ b/sample/WorkerServiceDemo/Worker.cs
@@ -27,6 +27,12 @@ namespace WorkerServiceDemo
             };
             _logger.LogInformation("{@Structured} {@Scalar}", structured, "Scalar Value");
 
+
+            // Logging a property with dots in its name to AdditionalColumn3
+            // but treat it as unstructured according to configuration in AdditionalColumns in appsettings.json
+            _logger.LogInformation("Non-structured property with dot-name to AdditionalColumn3 {@NonstructuredProperty.WithNameContainingDots.Name}",
+                new Random().Next().ToString());
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 _logger.LogInformation("Worker running at: {time}. CustomProperty1: {CustomProperty1}",

--- a/sample/WorkerServiceDemo/appsettings.json
+++ b/sample/WorkerServiceDemo/appsettings.json
@@ -27,7 +27,7 @@
               "columnName": "Timestamp",
               "convertToUtc": false
             },
-            "additionalColumns": [
+            "customColumns": [
               {
                 "columnName": "AdditionalColumn1",
                 "propertyName": "CustomProperty1",
@@ -36,6 +36,12 @@
               {
                 "columnName": "AdditionalColumn2",
                 "propertyName": "Structured.Name",
+                "dataType": "12"
+              },
+              {
+                "columnName": "AdditionalColumn3",
+                "propertyName": "NonstructuredProperty.WithNameContainingDots.Name",
+                "resolveHierarchicalPropertyName": false,
                 "dataType": "12"
               }
             ]
@@ -63,10 +69,21 @@
               "columnName": "Timestamp",
               "convertToUtc": false
             },
-            "additionalColumns": [
+            "customColumns": [
               {
                 "columnName": "AdditionalColumn1",
                 "propertyName": "CustomProperty1",
+                "dataType": "12"
+              },
+              {
+                "columnName": "AdditionalColumn2",
+                "propertyName": "Structured.Name",
+                "dataType": "12"
+              },
+              {
+                "columnName": "AdditionalColumn3",
+                "propertyName": "NonstructuredProperty.WithNameContainingDots.Name",
+                "resolveHierarchicalPropertyName": false,
                 "dataType": "12"
               }
             ]

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnCollection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnCollection.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,12 @@ namespace Serilog.Sinks.MSSqlServer
         protected override object GetElementKey(ConfigurationElement element)
         {
             return ((ColumnConfig)element)?.ColumnName;
+        }
+
+        // For testing
+        internal void Add(ColumnConfig config)
+        {
+            BaseAdd(config);
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnConfig.cs
@@ -1,11 +1,11 @@
 // Copyright 2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,6 +48,13 @@ namespace Serilog.Sinks.MSSqlServer
             set { this[nameof(PropertyName)] = value; }
         }
 
+        [ConfigurationProperty("ResolveHierarchicalPropertyName")]
+        public virtual string ResolveHierarchicalPropertyName
+        {
+            get { return (string)this[nameof(ResolveHierarchicalPropertyName)]; }
+            set { this[nameof(ResolveHierarchicalPropertyName)] = value; }
+        }
+
         [ConfigurationProperty("DataType")]
         public string DataType
         {
@@ -84,6 +91,8 @@ namespace Serilog.Sinks.MSSqlServer
             SetProperty.IfProvidedNotEmpty<string>(this, nameof(ColumnName), (val) => sqlColumn.ColumnName = val);
 
             SetProperty.IfProvidedNotEmpty<string>(this, nameof(PropertyName), (val) => sqlColumn.PropertyName = val);
+
+            SetProperty.IfProvided<bool>(this, nameof(ResolveHierarchicalPropertyName), (val) => sqlColumn.ResolveHierarchicalPropertyName = val);
 
             SetProperty.IfProvidedNotEmpty<string>(this, nameof(DataType), (val) => sqlColumn.SetDataTypeFromConfigString(val));
 

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server and Azure SQL</Description>
-    <VersionPrefix>8.0.1</VersionPrefix>
+    <VersionPrefix>8.1.0</VersionPrefix>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlColumn.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlColumn.cs
@@ -13,6 +13,7 @@ namespace Serilog.Sinks.MSSqlServer
         private SqlDbType _dataType = SqlDbType.VarChar; // backwards-compatibility default
         private string _columnName = string.Empty;
         private string _propertyName;
+        private bool _resolveHierarchicalPropertyName = true;
         private readonly List<string> _propertyNameHierarchy = new List<string>();
 
         /// <summary>
@@ -109,7 +110,20 @@ namespace Serilog.Sinks.MSSqlServer
             set
             {
                 _propertyName = value;
-                ParseHierarchicalPropertyName(value);
+                ParseHierarchicalPropertyName();
+            }
+        }
+
+        /// <summary>
+        /// Controls whether hierarchical expressions in `PropertyName` are evaluated. The default is `true`.
+        /// </summary>
+        public bool ResolveHierarchicalPropertyName
+        {
+            get => _resolveHierarchicalPropertyName;
+            set
+            {
+                _resolveHierarchicalPropertyName = value;
+                ParseHierarchicalPropertyName();
             }
         }
 
@@ -129,8 +143,6 @@ namespace Serilog.Sinks.MSSqlServer
         // allows Standard Columns and user-defined columns to coexist but remain identifiable
         // and allows casting back to the Standard Column without a lot of switch gymnastics.
         internal StandardColumn? StandardColumnIdentifier { get; set; }
-
-        internal Type StandardColumnType { get; set; }
 
         /// <summary>
         /// Converts a SQL sink SqlColumn object to a System.Data.DataColumn object. The original
@@ -170,9 +182,17 @@ namespace Serilog.Sinks.MSSqlServer
             DataType = sqlType;
         }
 
-        private void ParseHierarchicalPropertyName(string propertyName)
+        private void ParseHierarchicalPropertyName()
         {
-            _propertyNameHierarchy.AddRange(propertyName.Split('.'));
+            _propertyNameHierarchy.Clear();
+            if (ResolveHierarchicalPropertyName)
+            {
+                _propertyNameHierarchy.AddRange(PropertyName.Split('.'));
+            }
+            else
+            {
+                _propertyNameHierarchy.Add(PropertyName);
+            }
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Misc/AdditionalPropertiesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Misc/AdditionalPropertiesTests.cs
@@ -239,5 +239,63 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Misc
             VerifyStringColumnWritten(additionalColumn1Name, property1Value);
             VerifyIntegerColumnWritten(additionalColumn2Name, property2Value);
         }
+
+        [Fact]
+        public void WritesLogEventIgnoringHierarchicalNamedPropertiesWhenResolveHierarchicalPropertyNameIsFalse()
+        {
+            // Arrange
+            const string additionalColumn1Name = "AdditionalColumn1";
+            const string additionalProperty1Name = "AdditionalProperty1.SubProperty1";
+            const string additionalColumn2Name = "AdditionalColumn2";
+            const string additionalProperty2Name = "AdditionalProperty2.SubProperty2.SubSubProperty1";
+            var columnOptions = new MSSqlServer.ColumnOptions
+            {
+                AdditionalColumns = new List<SqlColumn>
+                {
+                    new SqlColumn
+                    {
+                        ColumnName = additionalColumn1Name,
+                        PropertyName = additionalProperty1Name,
+                        ResolveHierarchicalPropertyName = false,
+                        DataType = SqlDbType.NVarChar,
+                        AllowNull = true,
+                        DataLength = 100
+                    },
+                    new SqlColumn
+                    {
+                        ColumnName = additionalColumn2Name,
+                        PropertyName = additionalProperty2Name,
+                        ResolveHierarchicalPropertyName = false,
+                        DataType = SqlDbType.Int,
+                        AllowNull = true
+                    }
+                }
+            };
+            var property1Value = "PropertyValue1";
+            var property2Value = 2;
+
+            // Act
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.MSSqlServer(
+                    DatabaseFixture.LogEventsConnectionString,
+                    sinkOptions: new MSSqlServerSinkOptions
+                    {
+                        TableName = DatabaseFixture.LogTableName,
+                        AutoCreateSqlTable = true
+                    },
+                    columnOptions: columnOptions,
+                    formatProvider: CultureInfo.InvariantCulture)
+                .CreateLogger();
+            // Log event properties with names containing dots can be created using ForContext()
+            Log.ForContext(additionalProperty1Name, property1Value)
+                .ForContext(additionalProperty2Name, property2Value)
+                .Information("Hello {@AdditionalProperty1.SubProperty1} from thread {@AdditionalProperty2.SubProperty2.SubSubProperty1}");
+            Log.CloseAndFlush();
+
+            // Assert
+            VerifyDatabaseColumnsWereCreated(columnOptions.AdditionalColumns);
+            VerifyStringColumnWritten(additionalColumn1Name, property1Value);
+            VerifyIntegerColumnWritten(additionalColumn2Name, property2Value);
+        }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/SqlColumnTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/SqlColumnTests.cs
@@ -6,7 +6,7 @@ using static System.FormattableString;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Trait(TestCategory.TraitName, TestCategory.Unit)]
-    public class SqlServerColumnTests
+    public class SqlColumnTests
     {
         [Fact]
         public void DefaultsPropertyNameToColumnName()
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
         }
 
         [Fact]
-        public void StoresHierachicalPropertyName()
+        public void StoresHierarchicalPropertyName()
         {
             // Arrange
             const string propertyName1 = "TestPropertyName";
@@ -60,6 +60,52 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             Assert.Equal(propertyName2, sut.PropertyNameHierarchy[1]);
             Assert.Equal(propertyName3, sut.PropertyNameHierarchy[2]);
             Assert.True(sut.HasHierarchicalPropertyName);
+        }
+
+        [Fact]
+        public void WhenResolveHierarchicalPropertyNameSetFalseDoesNotStoreHierarchicalPropertyName()
+        {
+            // Arrange
+            const string propertyName1 = "TestPropertyName";
+            const string propertyName2 = "SubPropertyName";
+            const string propertyName3 = "SubSubPropertyName";
+            var propertyName = Invariant($"{propertyName1}.{propertyName2}.{propertyName3}");
+
+            // Act
+            var sut = new SqlColumn("TestColumnName", SqlDbType.Int)
+            {
+                PropertyName = propertyName,
+                ResolveHierarchicalPropertyName = false
+            };
+
+            // Assert
+            Assert.Equal(propertyName, sut.PropertyName);
+            Assert.Single(sut.PropertyNameHierarchy);
+            Assert.Equal(propertyName, sut.PropertyNameHierarchy[0]);
+            Assert.False(sut.HasHierarchicalPropertyName);
+        }
+
+        [Fact]
+        public void WhenResolveHierarchicalPropertyNameSetFalseAfterPropertyNameDoesNotStoreHierarchicalPropertyName()
+        {
+            // Arrange
+            const string propertyName1 = "TestPropertyName";
+            const string propertyName2 = "SubPropertyName";
+            const string propertyName3 = "SubSubPropertyName";
+            var propertyName = Invariant($"{propertyName1}.{propertyName2}.{propertyName3}");
+
+            // Act
+            var sut = new SqlColumn("TestColumnName", SqlDbType.Int)
+            {
+                PropertyName = propertyName,
+            };
+            sut.ResolveHierarchicalPropertyName = false;
+
+            // Assert
+            Assert.Equal(propertyName, sut.PropertyName);
+            Assert.Single(sut.PropertyNameHierarchy);
+            Assert.Equal(propertyName, sut.PropertyNameHierarchy[0]);
+            Assert.False(sut.HasHierarchicalPropertyName);
         }
     }
 }


### PR DESCRIPTION
Implements issue #542. See README.md and PR changes for details.