### PR TITLE
Remove obsolete exception handlers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 # 8.1.0
 * Implemented #542: Column option `ResolveHierarchicalPropertyName` to force non-hierarchical handling
-
-# 8.0.1
+* Removed unnecessary exception handlers and let Serilog Core do the SelfLog()
 * Refactoring and performance optimizations in batched and audit sink
 * Create perftest result on release
 * Updated issue template

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
@@ -60,12 +60,6 @@ namespace Serilog.Sinks.MSSqlServer.Platform
                     }
                 }
             }
-            catch (Exception ex)
-            {
-                SelfLog.WriteLine("Unable to write batch of {0} log events to the database due to following error: {1}",
-                    events.Count(), ex);
-                throw;
-            }
             finally
             {
                 _dataTable.Clear();


### PR DESCRIPTION
The sink had exceptions handlers when log events could not be written. Those handlers wrote an error message using Serilog's SelfLog() facility. This is now done by the Serilog Core when a sink's Emit() and EmitBatchAsync() methods throw an exception. This is why can remove our handlers, let exceptions propagate and Serilog Core do the work.