### PR TITLE
Fixed: dispose SqlBulkBatchWriter in sink

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -151,6 +151,7 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 if (disposing)
                 {
+                    _sqlBulkBatchWriter.Dispose();
                     _sqlLogEventWriter.Dispose();
                 }
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using Moq;
 using Serilog.Events;
 using Serilog.Parsing;
@@ -155,6 +154,16 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
             // Assert
             _sqlLogEventWriter.Verify(w => w.WriteEvent(logEvent), Times.Once);
+        }
+
+        [Fact]
+        public void OnDisposeDisposesSqlLogEventWriterDependency()
+        {
+            // Arrange + act
+            using (new MSSqlServerAuditSink(_sinkOptions, _columnOptions, _sinkDependencies)) { }
+
+            // Assert
+            _sqlLogEventWriter.Verify(w => w.Dispose(), Times.Once);
         }
 
         private void SetupSut(bool autoCreateSqlDatabase = false, bool autoCreateSqlTable = false)

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Threading.Tasks;
 using Moq;
 using Serilog.Events;
@@ -183,6 +182,26 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
             // Assert
             Assert.True(task.IsCompleted);
+        }
+
+        [Fact]
+        public void OnDisposeDisposesSqlBulkBatchWriterDependency()
+        {
+            // Arrange + act
+            using (new MSSqlServerSink(_sinkOptions, _sinkDependencies)) { }
+
+            // Assert
+            _sqlBulkBatchWriter.Verify(w => w.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void OnDisposeDisposesSqlLogEventWriterDependency()
+        {
+            // Arrange + act
+            using (new MSSqlServerSink(_sinkOptions, _sinkDependencies)) { }
+
+            // Assert
+            _sqlLogEventWriter.Verify(w => w.Dispose(), Times.Once);
         }
 
         private void SetupSut(

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
@@ -173,7 +173,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
         }
 
         [Fact]
-        public void OnEmpytBatchAsyncReturnsCompletedTask()
+        public void OnEmptyBatchAsyncReturnsCompletedTask()
         {
             // Arrange
             SetupSut();


### PR DESCRIPTION
A Dispose() call for _sqlBulkBatchWriter was missing in MSSqlServerSink class.