### PR TITLE
Fixed concurrency issue #607

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 8.1.1
+* Fixed concurrency issue #607 in audit sink
+
 # 8.1.0
 * Implemented #542: Column option `ResolveHierarchicalPropertyName` to force non-hierarchical handling
 * Removed unnecessary exception handlers and let Serilog Core do the SelfLog()

--- a/serilog-sinks-mssqlserver.sln
+++ b/serilog-sinks-mssqlserver.sln
@@ -28,13 +28,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
+		.github\workflows\perftests.yml = .github\workflows\perftests.yml
 		.github\workflows\pr-analysis-codeql.yml = .github\workflows\pr-analysis-codeql.yml
 		.github\workflows\pr-analysis-devskim.yml = .github\workflows\pr-analysis-devskim.yml
 		.github\workflows\pr-validation.yml = .github\workflows\pr-validation.yml
 		README.md = README.md
 		.github\workflows\release.yml = .github\workflows\release.yml
 		RunPerfTests.ps1 = RunPerfTests.ps1
-		.github\workflows\perftests.yml = .github\workflows\perftests.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetStandardDemoLib", "sample\NetStandardDemo\NetStandardDemoLib\NetStandardDemoLib.csproj", "{8E69E31B-61C7-4175-B886-9C2078FCA477}"

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2024 Serilog Contributors
+﻿// Copyright 2025 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2024 Serilog Contributors
+﻿// Copyright 2025 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -26,7 +26,7 @@ namespace Serilog.Sinks.MSSqlServer
     /// Writes log events as rows in a table of MSSqlServer database using Audit logic, meaning that each row is synchronously committed
     /// and any errors that occur are propagated to the caller.
     /// </summary>
-    public class MSSqlServerAuditSink : ILogEventSink
+    public class MSSqlServerAuditSink : ILogEventSink, IDisposable
     {
         private readonly ISqlLogEventWriter _sqlLogEventWriter;
 
@@ -96,6 +96,25 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent) =>
             _sqlLogEventWriter.WriteEvent(logEvent);
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the Serilog.Sinks.MSSqlServer.MSSqlServerAuditSink and optionally
+        /// releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">True to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // This class needn't to dispose anything. This is just here for sink interface compatibility.
+        }
 
         private static void ValidateParameters(MSSqlServerSinkOptions sinkOptions, ColumnOptions columnOptions)
         {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -26,11 +26,9 @@ namespace Serilog.Sinks.MSSqlServer
     /// Writes log events as rows in a table of MSSqlServer database using Audit logic, meaning that each row is synchronously committed
     /// and any errors that occur are propagated to the caller.
     /// </summary>
-    public class MSSqlServerAuditSink : ILogEventSink, IDisposable
+    public class MSSqlServerAuditSink : ILogEventSink
     {
         private readonly ISqlLogEventWriter _sqlLogEventWriter;
-
-        private bool _disposedValue;
 
         /// <summary>
         /// Construct a sink posting to the specified database.
@@ -98,33 +96,6 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent) =>
             _sqlLogEventWriter.WriteEvent(logEvent);
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the Serilog.Sinks.MSSqlServer.MSSqlServerAuditSink and optionally
-        /// releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">True to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _sqlLogEventWriter.Dispose();
-                }
-
-                _disposedValue = true;
-            }
-        }
 
         private static void ValidateParameters(MSSqlServerSinkOptions sinkOptions, ColumnOptions columnOptions)
         {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2024 Serilog Contributors
+﻿// Copyright 2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2024 Serilog Contributors
+﻿// Copyright 2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -152,7 +152,6 @@ namespace Serilog.Sinks.MSSqlServer
                 if (disposing)
                 {
                     _sqlBulkBatchWriter.Dispose();
-                    _sqlLogEventWriter.Dispose();
                 }
 
                 _disposedValue = true;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/IXmlPropertyFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/IXmlPropertyFormatter.cs
@@ -1,18 +1,4 @@
-﻿// Copyright 2024 Serilog Contributors
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Serilog.Sinks.MSSqlServer.Output
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
@@ -1,17 +1,3 @@
-// Copyright 2024 Serilog Contributors
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlCommandFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlCommandFactory.cs
@@ -4,7 +4,6 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 {
     internal interface ISqlCommandFactory
     {
-        ISqlCommandWrapper CreateCommand(ISqlConnectionWrapper sqlConnection);
         ISqlCommandWrapper CreateCommand(string cmdText, ISqlConnectionWrapper sqlConnection);
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlLogEventWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlLogEventWriter.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Serilog.Events;
 
 namespace Serilog.Sinks.MSSqlServer.Platform
 {
-    internal interface ISqlLogEventWriter : IDisposable
+    internal interface ISqlLogEventWriter
     {
         void WriteEvent(LogEvent logEvent);
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
-using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer.Output;
 
@@ -45,10 +43,10 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             {
                 FillDataTable(events);
 
-                using (var cn = _sqlConnectionFactory.Create())
+                using (var sqlConnection = _sqlConnectionFactory.Create())
                 {
-                    await cn.OpenAsync().ConfigureAwait(false);
-                    using (var copy = cn.CreateSqlBulkCopy(_disableTriggers, _schemaAndTableName))
+                    await sqlConnection.OpenAsync().ConfigureAwait(false);
+                    using (var copy = sqlConnection.CreateSqlBulkCopy(_disableTriggers, _schemaAndTableName))
                     {
                         for (var i = 0; i < _dataTable.Columns.Count; i++)
                         {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/ISqlCommandWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/ISqlCommandWrapper.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Data;
 using System.Threading.Tasks;
-using Microsoft.Data.SqlClient;
 
 namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
 {
     internal interface ISqlCommandWrapper : IDisposable
     {
-        CommandType CommandType { get; set; }
-        string CommandText { get; set; }
-
-        void SetConnection(ISqlConnectionWrapper sqlConnectionWrapper);
-        void ClearParameters();
         void AddParameter(string parameterName, object value);
         int ExecuteNonQuery();
         Task<int> ExecuteNonQueryAsync();

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapper.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapper.cs
@@ -10,32 +10,9 @@ namespace Serilog.Sinks.MSSqlServer.Platform.SqlClient
         private readonly SqlCommand _sqlCommand;
         private bool _disposedValue;
 
-        public SqlCommandWrapper(SqlCommand sqlCommand, SqlConnection sqlConnection)
+        public SqlCommandWrapper(SqlCommand sqlCommand)
         {
             _sqlCommand = sqlCommand ?? throw new ArgumentNullException(nameof(sqlCommand));
-            _sqlCommand.Connection = sqlConnection ?? throw new ArgumentNullException(nameof(sqlConnection));
-        }
-
-        public CommandType CommandType
-        {
-            get => _sqlCommand.CommandType;
-            set => _sqlCommand.CommandType = value;
-        }
-
-        public string CommandText
-        {
-            get => _sqlCommand.CommandText;
-            set => _sqlCommand.CommandText = value;
-        }
-
-        public void SetConnection(ISqlConnectionWrapper sqlConnectionWrapper)
-        {
-            _sqlCommand.Connection = sqlConnectionWrapper.SqlConnection;
-        }
-
-        public void ClearParameters()
-        {
-            _sqlCommand.Parameters.Clear();
         }
 
         public void AddParameter(string parameterName, object value)

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCommandFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlCommandFactory.cs
@@ -5,16 +5,10 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 {
     internal class SqlCommandFactory : ISqlCommandFactory
     {
-        public ISqlCommandWrapper CreateCommand(ISqlConnectionWrapper sqlConnection)
-        {
-            var sqlCommand = new SqlCommand();
-            return new SqlCommandWrapper(sqlCommand, sqlConnection.SqlConnection);
-        }
-
         public ISqlCommandWrapper CreateCommand(string cmdText, ISqlConnectionWrapper sqlConnection)
         {
-            var sqlCommand = new SqlCommand(cmdText);
-            return new SqlCommandWrapper(sqlCommand, sqlConnection.SqlConnection);
+            var sqlCommand = new SqlCommand(cmdText, sqlConnection.SqlConnection);
+            return new SqlCommandWrapper(sqlCommand);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.PerformanceTests/Sinks/MSSqlServer/Platform/SqlInsertStatementWriterBenchmarks.cs
+++ b/test/Serilog.Sinks.MSSqlServer.PerformanceTests/Sinks/MSSqlServer/Platform/SqlInsertStatementWriterBenchmarks.cs
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.MSSqlServer.PerformanceTests.Platform;
 
 [MemoryDiagnoser]
 [MaxIterationCount(16)]
-public class SqlInsertStatementWriterBenchmarks : IDisposable
+public class SqlInsertStatementWriterBenchmarks
 {
     private const string _tableName = "TestTableName";
     private const string _schemaName = "TestSchemaName";
@@ -35,7 +35,7 @@ public class SqlInsertStatementWriterBenchmarks : IDisposable
         _sqlCommandWrapperMock = new Mock<ISqlCommandWrapper>();
 
         _sqlConnectionFactoryMock.Setup(f => f.Create()).Returns(_sqlConnectionWrapperMock.Object);
-        _sqlCommandFactoryMock.Setup(f => f.CreateCommand(It.IsAny<ISqlConnectionWrapper>()))
+        _sqlCommandFactoryMock.Setup(f => f.CreateCommand(It.IsAny<string>(), It.IsAny<ISqlConnectionWrapper>()))
             .Returns(_sqlCommandWrapperMock.Object);
 
         CreateLogEvents();
@@ -66,11 +66,5 @@ public class SqlInsertStatementWriterBenchmarks : IDisposable
         {
             _logEvents.Add(CreateLogEvent());
         }
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        _sut.Dispose();
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Trait(TestCategory.TraitName, TestCategory.Unit)]
-    public class MSSqlServerAuditSinkTests : IDisposable
+    public class MSSqlServerAuditSinkTests
     {
         private readonly MSSqlServerSinkOptions _sinkOptions;
         private readonly Serilog.Sinks.MSSqlServer.ColumnOptions _columnOptions;
@@ -22,7 +22,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
         private readonly string _tableName = "tableName";
         private readonly string _schemaName = "schemaName";
         private MSSqlServerAuditSink _sut;
-        private bool _disposedValue;
 
         public MSSqlServerAuditSinkTests()
         {
@@ -156,36 +155,11 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             _sqlLogEventWriter.Verify(w => w.WriteEvent(logEvent), Times.Once);
         }
 
-        [Fact]
-        public void OnDisposeDisposesSqlLogEventWriterDependency()
-        {
-            // Arrange + act
-            using (new MSSqlServerAuditSink(_sinkOptions, _columnOptions, _sinkDependencies)) { }
-
-            // Assert
-            _sqlLogEventWriter.Verify(w => w.Dispose(), Times.Once);
-        }
-
         private void SetupSut(bool autoCreateSqlDatabase = false, bool autoCreateSqlTable = false)
         {
             _sinkOptions.AutoCreateSqlDatabase = autoCreateSqlDatabase;
             _sinkOptions.AutoCreateSqlTable = autoCreateSqlTable;
             _sut = new MSSqlServerAuditSink(_sinkOptions, _columnOptions, _sinkDependencies);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                _sut?.Dispose();
-                _disposedValue = true;
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerAuditSinkTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Trait(TestCategory.TraitName, TestCategory.Unit)]
-    public class MSSqlServerAuditSinkTests
+    public class MSSqlServerAuditSinkTests : IDisposable
     {
         private readonly MSSqlServerSinkOptions _sinkOptions;
         private readonly Serilog.Sinks.MSSqlServer.ColumnOptions _columnOptions;
@@ -22,6 +22,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
         private readonly string _tableName = "tableName";
         private readonly string _schemaName = "schemaName";
         private MSSqlServerAuditSink _sut;
+        private bool _disposedValue;
 
         public MSSqlServerAuditSinkTests()
         {
@@ -160,6 +161,21 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             _sinkOptions.AutoCreateSqlDatabase = autoCreateSqlDatabase;
             _sinkOptions.AutoCreateSqlTable = autoCreateSqlTable;
             _sut = new MSSqlServerAuditSink(_sinkOptions, _columnOptions, _sinkDependencies);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                _sut?.Dispose();
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTests.cs
@@ -194,16 +194,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             _sqlBulkBatchWriter.Verify(w => w.Dispose(), Times.Once);
         }
 
-        [Fact]
-        public void OnDisposeDisposesSqlLogEventWriterDependency()
-        {
-            // Arrange + act
-            using (new MSSqlServerSink(_sinkOptions, _sinkDependencies)) { }
-
-            // Assert
-            _sqlLogEventWriter.Verify(w => w.Dispose(), Times.Once);
-        }
-
         private void SetupSut(
             bool autoCreateSqlDatabase = false,
             bool autoCreateSqlTable = false,

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapperTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlClient/SqlCommandWrapperTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.Data.SqlClient;
-using Moq;
 using Xunit;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;
@@ -13,23 +12,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform.SqlClient
         [Fact]
         public void InitializeThrowsIfSqlCommandIsNull()
         {
-            // Arrange
-            using (var sqlConnection = new SqlConnection())
-            {
-                // Act
-                Assert.Throws<ArgumentNullException>(() => new SqlCommandWrapper(null, sqlConnection));
-            }
-        }
-
-        [Fact]
-        public void InitializeThrowsIfSqlConnectionIsNull()
-        {
-            // Arrange
-            using (var sqlCommand = new SqlCommand())
-            {
-                // Act
-                Assert.Throws<ArgumentNullException>(() => new SqlCommandWrapper(sqlCommand, null));
-            }
+            // Arrange + act
+            Assert.Throws<ArgumentNullException>(() => new SqlCommandWrapper(null));
         }
 
         [Fact]
@@ -38,60 +22,12 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform.SqlClient
             // Arrange
             using (var sqlConnection = new SqlConnection())
             {
-                using (var sqlCommand = new SqlCommand())
+                using (var sqlCommand = new SqlCommand("SELECT * FROM Table WHERE Id = @Parameter", sqlConnection))
                 {
-                    using (var sut = new SqlCommandWrapper(sqlCommand, sqlConnection))
+                    using (var sut = new SqlCommandWrapper(sqlCommand))
                     {
                         // Act (should not throw)
                         sut.AddParameter("Parameter", "Value");
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void SetConnectionCallsSetConnectionOnSqlCommand()
-        {
-            // Arrange
-            using (var sqlConnection = new SqlConnection())
-            {
-                using (var sqlCommand = new SqlCommand())
-                {
-                    using (var sut = new SqlCommandWrapper(sqlCommand, sqlConnection))
-                    {
-                        using (var sqlConnection2 = new SqlConnection())
-                        {
-                            var sqlConnectionWrapperMock = new Mock<ISqlConnectionWrapper>();
-                            sqlConnectionWrapperMock.SetupGet(c => c.SqlConnection).Returns(sqlConnection2);
-
-                            // Act
-                            sut.SetConnection(sqlConnectionWrapperMock.Object);
-
-                            // Assert
-                            Assert.Same(sqlConnection2, sqlCommand.Connection);
-                        }
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void ClearParametersCallsClearParametersOnSqlCommand()
-        {
-            // Arrange
-            using (var sqlConnection = new SqlConnection())
-            {
-                using (var sqlCommand = new SqlCommand())
-                {
-                    sqlCommand.Parameters.Add(new SqlParameter());
-                    sqlCommand.Parameters.Add(new SqlParameter());
-                    using (var sut = new SqlCommandWrapper(sqlCommand, sqlConnection))
-                    {
-                        // Act
-                        sut.ClearParameters();
-
-                        // Assert
-                        Assert.Empty(sqlCommand.Parameters);
                     }
                 }
             }


### PR DESCRIPTION
* Bugfix #607: Do not reuse SqlCommand because apparently it is not threadsafe. Set connection on command leads to a exception in audit sink under heavy load.
* Fixed a glitch in solution file
* Updated copyright year
* Updated changelog
