### PR TITLE
Fixed issue #624 (2nd try)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.71.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.73.1" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="Dapper.StrongName" Version="2.1.35" />


### PR DESCRIPTION
Enforce new version of transient dependency to fix vulnerability and avoid nuget.org version de-listing until SqlClient 6.1 is released.

Now updated the vulnerable dependency (Microsoft.Identity.Client) to it's latest version 4.73.1 because even 4.72.1 is marked deprecated on nuget.org. This should hopefully satisfy the security scanners at nuget.org.